### PR TITLE
Added Translatable support

### DIFF
--- a/code/tasks/SiteTreeFullBuildEngine.php
+++ b/code/tasks/SiteTreeFullBuildEngine.php
@@ -133,6 +133,9 @@ class SiteTreeFullBuildEngine extends BuildTask {
 		if(class_exists('Subsite')) {
 			Subsite::disable_subsite_filter(true);
 		}
+		if(class_exists('Translatable')) {
+			Translatable::disable_locale_filter();
+		}		
 		Versioned::reading_stage('Live');
 		$pages = DataObject::get("SiteTree");
 		Versioned::set_reading_mode($oldMode);


### PR DESCRIPTION
SiteTreeFullBuildEngine would only add pages with the default locale to the queue. This change checks if Translatable exists, if yes it disables the locale filter to return all urls.

I'm not certain this is the best way to do this, but it works as far as I can tell. Basically I just copied the code form 3 lines above for the Subsite Module.
