### PR TITLE
FIX: stale-static-main.example.php path to main.php

### DIFF
--- a/docs/en/stale-static-main.example.php
+++ b/docs/en/stale-static-main.example.php
@@ -116,12 +116,12 @@ if (CACHE_ENABLED
 	} else {
 		// No cache hit... fallback to dynamic routing
 		header('X-SilverStripe-Cache: miss at '.@date('r').' on '.$cacheDir.$file);
-		include BASE_PATH.DIRECTORY_SEPARATOR.'sapphire/main.php';
+		include BASE_PATH.DIRECTORY_SEPARATOR.'framework/main.php';
 		if (CACHE_DEBUG) echo "<h1>File was NOT cached</h1>";
 	}
 } else {
 	// Fall back to dynamic generation via normal routing if caching has been explicitly disabled
-	include BASE_PATH.DIRECTORY_SEPARATOR.'sapphire/main.php';
+	include BASE_PATH.DIRECTORY_SEPARATOR.'framework/main.php';
 }
 
 ?>


### PR DESCRIPTION
The path to main.php changed from sapphire/main.php to framework/main.php a while ago. Update to the sample file to reflect that.
