### PR TITLE
Prevent [Warning] MySQLDatabase::affectedRows(): Property access is not ...

### DIFF
--- a/code/model/StaticPagesQueue.php
+++ b/code/model/StaticPagesQueue.php
@@ -109,7 +109,7 @@ class StaticPagesQueue extends DataObject {
 		}
 		self::remove_old_cache(self::$urls);
 		// Flush the cache so DataObject::get works correctly
-		if(DB::affectedRows()) {
+		if(!empty(self::$insert_statements) && DB::affectedRows()) {
 			singleton(__CLASS__)->flushCache();
 		}
 		self::$insert_statements = array();


### PR DESCRIPTION
...allowed yet

If no updates performed then there is no $this->dbConn->affected_rows; and a warning is thrown
