### PR TITLE
Add ability to skip pages being cached

### DIFF
--- a/code/tasks/SiteTreeFullBuildEngine.php
+++ b/code/tasks/SiteTreeFullBuildEngine.php
@@ -99,8 +99,9 @@ class SiteTreeFullBuildEngine extends BuildTask {
 		// Collect all URLs into the queue
 		foreach($pages as $page) {
 			
-			if (is_callable(array($page, 'canCache')) && !$page->canCache())
+			if (is_callable(array($page, 'canCache')) && !$page->canCache()) {
 				continue;
+			}
 				
 			if (is_callable(array($page, 'urlsToCache'))) {
 				$this->getUrlArrayObject()->addUrlsOnBehalf($page->urlsToCache(), $page);

--- a/code/tasks/SiteTreeFullBuildEngine.php
+++ b/code/tasks/SiteTreeFullBuildEngine.php
@@ -102,7 +102,7 @@ class SiteTreeFullBuildEngine extends BuildTask {
 		foreach($pages as $page) {
 
 			if (is_callable(array($page, 'canCache')) && !$page->canCache()) {
-				$arrNonCachedPages[] =
+				$arrNonCachedPages[] = $page;
 				continue;
 			}
 

--- a/code/tasks/SiteTreeFullBuildEngine.php
+++ b/code/tasks/SiteTreeFullBuildEngine.php
@@ -98,6 +98,10 @@ class SiteTreeFullBuildEngine extends BuildTask {
 
 		// Collect all URLs into the queue
 		foreach($pages as $page) {
+			
+			if (is_callable(array($page, 'canCache')) && !$page->canCache())
+				continue;
+				
 			if (is_callable(array($page, 'urlsToCache'))) {
 				$this->getUrlArrayObject()->addUrlsOnBehalf($page->urlsToCache(), $page);
 				$count++;


### PR DESCRIPTION
When there are pages that we don't want published statically (e.g. pages with access restrictions by group) this allows us to do that with the least change required to the module.
