### PR TITLE
Fix: setting error fails if record does not exist

### DIFF
--- a/code/model/StaticPagesQueue.php
+++ b/code/model/StaticPagesQueue.php
@@ -146,6 +146,8 @@ class StaticPagesQueue extends DataObject {
 		if(!$url) return;
 		
 		$existingObject = self::get_by_link($url);
+        if(!$existingObject) return;
+        
 		$existingObject->Freshness = 'error';
 		$existingObject->write();
 	}


### PR DESCRIPTION
StaticPagesQueue::has_error loads object by url. If the object does not exist (any longer) the code will fail crashing the BuildQue.
Added check to ensure a record was found, otherwise there is no point in setting the error.