### PR TITLE
Fixes for PostgreSQL databases

### DIFF
--- a/code/model/BuildStaticCacheSummary.php
+++ b/code/model/BuildStaticCacheSummary.php
@@ -8,7 +8,7 @@ class BuildStaticCacheSummary extends DataObject {
 
 	public static $db = array(
 		'Pages' => 'Int',
-		'TotalTime' => 'Int',
+		'TotalTime' => 'Float',
 		'AverageTime' => 'Float',
 		'MemoryUsage' => 'Float',
 		'PID' => 'Int',

--- a/code/reports/BuildStaticCacheSummaryReport.php
+++ b/code/reports/BuildStaticCacheSummaryReport.php
@@ -55,7 +55,7 @@ class BuildStaticCacheSummaryReport extends SS_Report {
 
 			$sort = $field.' '.$direction;
 		} else {
-			$sort = $this->dataClass.'.ID DESC';
+			$sort = Convert::symbol2sql("$this->dataClass.ID").' DESC';
 		}
 
 		return DataObject::get($this->dataClass, "", $sort, null, $limit);


### PR DESCRIPTION
- PostgreSQL will fail if you try to save a float to an int field
- PostgreSQL needs table and column names to be quoted