### PR TITLE
Fix excludeFromCache not working with SiteTreePublishingEngine

### DIFF
--- a/code/model/URLArrayObject.php
+++ b/code/model/URLArrayObject.php
@@ -122,17 +122,18 @@ class URLArrayObject extends ArrayObject {
 	}
 
 	protected function excludeFromCache($url) {
-		$excluded = false;
+		$candidatePage = $this->getObject($url);
 
-		//don't publish objects that are excluded from cache
-		$candidatePage = SiteTree::get_by_link($url);
-		if (!empty($candidatePage)) {
-			if (!empty($candidatePage->excludeFromCache)) {
-				$excluded = true;
-			}
+		if (empty($candidatePage)) {
+			$cleanUrl = $this->removeQueryStringFromUrl($url);
+			$candidatePage = SiteTree::get_by_link($cleanUrl);
 		}
 
-		return $excluded;
+		return !empty($candidatePage) && !empty($candidatePage->excludeFromCache);
+	}
+
+	private function removeQueryStringFromUrl($url) {
+		return strtok($url, '?');
 	}
 
 	/**

--- a/tests/unit/URLArrayObjectTest.php
+++ b/tests/unit/URLArrayObjectTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @mixin PHPUnit_Framework_Assert
+ */
+class URLArrayObjectTest extends SapphireTest {
+
+	protected static $fixture_file = 'URLArrayObjectTestFixture.yml';
+	protected $extraDataObjects = array('URLArrayObjectTestPage');
+	protected $requiredExtensions = array(
+		'SiteTree' => array('SiteTreePublishingEngine')
+	);
+
+	public function testExcludeFromCacheExcludesPageURLs() {
+		/** @var URLArrayObject $urlArrayObject */
+		$urlArrayObject = singleton('SiteTree')->urlArrayObject;
+		$method = $this->getProtectedOrPrivateMethod('excludeFromCache');
+
+		/** @var SiteTree $excluded */
+		$excluded = $this->objFromFixture('URLArrayObjectTestPage', 'excluded');
+		/** @var SiteTree $included */
+		$included = $this->objFromFixture('URLArrayObjectTestPage', 'included');
+
+		$this->assertEquals(true, $method->invoke($urlArrayObject, $excluded->Link()));
+		$this->assertEquals(false, $method->invoke($urlArrayObject, $included->Link()));
+	}
+
+	public function testExcludeFromCacheExcludesPageURLsWithQueryStrings() {
+		/** @var URLArrayObject $urlArrayObject */
+		$urlArrayObject = singleton('SiteTree')->urlArrayObject;
+		$method = $this->getProtectedOrPrivateMethod('excludeFromCache');
+
+		/** @var SiteTree $excluded */
+		$excluded = $this->objFromFixture('URLArrayObjectTestPage', 'excluded');
+		/** @var SiteTree $included */
+		$included = $this->objFromFixture('URLArrayObjectTestPage', 'included');
+
+		$this->assertEquals(true, $method->invoke($urlArrayObject, $excluded->Link() . '?query=string'));
+		$this->assertEquals(false, $method->invoke($urlArrayObject, $included->Link() . '?query=string'));
+	}
+
+	public function testExcludeFromCachePrefersObjectAnnotationOverUrls() {
+		/** @var URLArrayObject $urlArrayObject */
+		$urlArrayObject = singleton('SiteTree')->urlArrayObject;
+		$method = $this->getProtectedOrPrivateMethod('excludeFromCache');
+
+		/** @var SiteTree $excluded */
+		$excluded = $this->objFromFixture('URLArrayObjectTestPage', 'excluded');
+		/** @var SiteTree $included */
+		$included = $this->objFromFixture('URLArrayObjectTestPage', 'included');
+
+		$actuallyExcludedUrl = $included->RelativeLink . "?_ID=$excluded->ID&_ClassName=$excluded->ClassName";
+		$actuallyIncludedUrl = $excluded->RelativeLink . "?_ID=$included->ID&_ClassName=$included->ClassName";
+		$this->assertEquals(true, $method->invoke($urlArrayObject, $actuallyExcludedUrl));
+		$this->assertEquals(false, $method->invoke($urlArrayObject, $actuallyIncludedUrl));
+	}
+
+	private function getProtectedOrPrivateMethod($name) {
+		$method = new ReflectionMethod('URLArrayObject', $name);
+		$method->setAccessible(true);
+
+		return $method;
+	}
+}
+
+class URLArrayObjectTestPage extends SiteTree implements TestOnly
+{
+	private static $db = array(
+		'excludeFromCache' => 'Boolean'
+	);
+}

--- a/tests/unit/URLArrayObjectTestFixture.yml
+++ b/tests/unit/URLArrayObjectTestFixture.yml
@@ -1,0 +1,7 @@
+URLArrayObjectTestPage:
+  excluded:
+    URLSegment: exclude-from-cache
+    excludeFromCache: true
+  included:
+    URLSegment: include-in-cache
+    excludeFromCache: false


### PR DESCRIPTION
`URLArrayObject#addObject` adds metadata to the query string of the URL segment that's added to the queue. `#excludeFromCache` passes this query string through to `SiteTree::get_by_link`, which doesn't understand query strings and returns nothing.

There is also an issue with Subsites: SiteTreePublishingEngine disables Subsite filtering, meaning the `SiteTree::get_by_link` will always return the first URL that matches rather than the one indicated by the URL's metadata.

This changes fixes both issues by trying to retrieve the object first using `URLArrayObject#getObject`, and then falling back to a clean (query-string-free) URL passed to `SiteTree::get_by_link`.