### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
 	"type": "silverstripe-module",
 	"keywords": ["silverstripe", "static", "html", "security", "performance", "static-publishing", "caching", "cache", "static-caching", "static-cache", "queue", "publishing"],
 	"require": {
-		"silverstripe/framework": ">=3.1.0",
-		"silverstripe/cms": ">=3.1.0",
+		"silverstripe/framework": "^3.1.0",
+		"silverstripe/cms": "^3.1.0",
 		"silverstripe/gridfieldajaxrefresh": "dev-master"
 	},
 	"minimum-stability": "dev"


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.