### PR TITLE
FIX GenerateStaticCacheJob should increment the step as it completes them

### DIFF
--- a/src/Job/GenerateStaticCacheJob.php
+++ b/src/Job/GenerateStaticCacheJob.php
@@ -32,6 +32,7 @@ class GenerateStaticCacheJob extends Job
                 unset($this->jobData->URLsToProcess[$url]);
             }
         }
+        $this->currentStep++;
         $this->isComplete = empty($this->jobData->URLsToProcess);
     }
 }


### PR DESCRIPTION
Currently this job does not increment the step counter as it runs through URLs. This means that if the job is running more than 600 URLs then it would marked as stalled. Why 600 URLs? QueuedJobs will process the job 3 times before deciding that "current step is not increasing" is a problem.