### PR TITLE
FIX FullBuildJob processing same URLs multiple times

### DIFF
--- a/src/Job/StaticCacheFullBuildJob.php
+++ b/src/Job/StaticCacheFullBuildJob.php
@@ -47,6 +47,15 @@ class StaticCacheFullBuildJob extends Job
     {
         $chunkSize = self::config()->get('chunk_size');
         $count = 0;
+
+        // Remove any URLs which have already been processed
+        if ($this->jobData->ProcessedURLs) {
+            $this->jobData->URLsToProcess = array_diff_key(
+                $this->jobData->URLsToProcess,
+                $this->jobData->ProcessedURLs
+            );
+        }
+
         foreach ($this->jobData->URLsToProcess as $url => $priority) {
             if (++$count > $chunkSize) {
                 break;


### PR DESCRIPTION
I ran into an issue performing a Full build of a site with a lot of URLs, as the job hits the chunk_size and re-initialises it seems like it doesn't retain the `URLsToProcess` of the previous run of the job. The job then starts building the cache as if it hadn't processed any URLs, so hits the chunk_size again and just gets stuck in a loop of rebuilding the first few URLs but never finishing the job.