### PR TITLE
FIX FilesystemPublisher now writes to a temporary file then moves it to the desired path

### DIFF
--- a/src/Publisher/FilesystemPublisher.php
+++ b/src/Publisher/FilesystemPublisher.php
@@ -163,9 +163,18 @@ class FilesystemPublisher extends Publisher
         if (empty($content)) {
             return false;
         }
+
+        // Write to a temporary file first
+        $temporaryPath = tempnam(TEMP_PATH, 'filesystempublisher_');
+        if (file_put_contents($temporaryPath, $content) === false) {
+            return false;
+        }
+
+        // Move the temporary file to the desired location (prevents unlocked files from being read during write)
         $publishPath = $this->getDestPath() . DIRECTORY_SEPARATOR . $filePath;
         Filesystem::makeFolder(dirname($publishPath));
-        return file_put_contents($publishPath, $content) !== false;
+
+        return rename($temporaryPath, $publishPath);
     }
 
     protected function deleteFromPath($filePath)

--- a/tests/php/Publisher/FilesystemPublisherTest.php
+++ b/tests/php/Publisher/FilesystemPublisherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\StaticPublishQueue\Test;
+namespace SilverStripe\StaticPublishQueue\Test\Publisher;
 
 use SilverStripe\Assets\Filesystem;
 use SilverStripe\CMS\Model\RedirectorPage;
@@ -8,7 +8,6 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPApplication;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\Core\Environment;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestKernel;
 use SilverStripe\StaticPublishQueue\Extension\Publishable\PublishableSiteTree;


### PR DESCRIPTION
This prevents issues where file_put_contents() does not request a file lock during writes, so processes may pick up an empty file during the process. Instead, we write to a system temp directory and rename it at the end to the desired filename.

Also renames the test class for the publisher so it makes a predictable namespace.

Fixes #90 