### PR TITLE
Add DB index on URLSegment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 sudo: false
 
 php: 
- - 5.3
+ - 5.6
 
 env:
  - DB=MYSQL CORE_RELEASE=3.1

--- a/code/model/StaticPagesQueue.php
+++ b/code/model/StaticPagesQueue.php
@@ -50,6 +50,7 @@ class StaticPagesQueue extends DataObject {
 	 */
 	public static $indexes = array(
 		'freshness_priority_created' => '(Freshness, Priority, Created)',
+		'URLSegment' => true,
 	);
 
 	/**


### PR DESCRIPTION
This will speed up operations as `delete_by_link` and `has_error` if the StaticPagesQueue table contains a 100,000s of rows. 

Note this a SilverStripe version 3.X improvement only, since the master branch is 4.X and uses queued jobs module as a scheduler.

