### PR TITLE
Ensure URLs get queued when BASE_URL is set

### DIFF
--- a/code/model/URLArrayObject.php
+++ b/code/model/URLArrayObject.php
@@ -98,8 +98,7 @@ class URLArrayObject extends ArrayObject {
 			//only add URLs of a certain length and only add URLs not already added
 			if (!empty($URLSegment) &&
 			    strlen($URLSegment) > 0 &&
-			    !isset($urlsAlreadyProcessed[$URLSegment]) &&
-				substr($URLSegment,0,4) != "http") {    //URLs isn't to an external site
+			    !isset($urlsAlreadyProcessed[$URLSegment])) {
 
 				//check to make sure this page isn't excluded from the cache
 				if (!$this->excludeFromCache($URLSegment)) {


### PR DESCRIPTION
when BASE_URL is set, which is pretty much a must when running on https, URLs won't get queued due to something that I presume is a very old and legacy check.