### PR TITLE
Configuration / extensibility improvements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,30 @@
 language: php
 
-env:
-  global:
-    - COMPOSER_ROOT_VERSION=2.0.x-dev
+dist: trusty
 
 matrix:
   include:
-    - php: 5.6
-      env: DB=MYSQL RECIPE_VERSION=1.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
-    - php: 7.0
-      env: DB=MYSQL RECIPE_VERSION=1.1.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=PGSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
+    - php: 7.1
+      env: DB=PGSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1 PHPUNIT_COVERAGE_TEST=1
+    - php: 7.1
+      env: DB=MYSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_TEST=1
     - php: 7.2
-      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
-    - php: 7.2
+      env: DB=MYSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_TEST=1
+    - php: 7.3
+      env: DB=MYSQL RECIPE_VERSION=4.5.x-dev PHPUNIT_TEST=1
+    - php: 7.3
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
 
 before_script:
-  # Init PHP
   - phpenv rehash
   - phpenv config-rm xdebug.ini
   - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
-  # Install composer dependencies
   - composer validate
-  - composer require --no-update silverstripe/recipe-cms "$RECIPE_VERSION"
-  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql 2.1.x-dev; fi
+  - composer require --no-update silverstripe/recipe-cms:"$RECIPE_VERSION"
+  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.x-dev; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,11 @@
     "type": "silverstripe-vendormodule",
     "keywords": ["silverstripe", "static", "html", "security", "performance", "static-publishing", "caching", "cache", "static-caching", "static-cache", "queue", "publishing"],
     "require": {
+        "php": "^7.1",
         "silverstripe/framework": "^4.0.2",
         "silverstripe/cms": "^4",
         "silverstripe/config": "^1",
-        "symbiote/silverstripe-queuedjobs": "^4.0.6",
+        "symbiote/silverstripe-queuedjobs": "^4.5.0",
         "silverstripe/versioned": "^1.0.2"
     },
     "require-dev": {

--- a/src/Job.php
+++ b/src/Job.php
@@ -4,30 +4,264 @@ namespace SilverStripe\StaticPublishQueue;
 
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extensible;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\StaticPublishQueue\Contract\StaticallyPublishable;
-use SilverStripe\StaticPublishQueue\Extension\Publishable\PublishableSiteTree;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\StaticPublishQueue\Service\URLSanitisationService;
+use stdClass;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 abstract class Job extends AbstractQueuedJob
 {
     use Configurable;
     use Extensible;
+    use Injectable;
 
     /**
+     * Number of URLs per job allows you to split work into multiple smaller jobs instead of having one large job
+     * this is useful if you're running a queue setup will parallel processing
+     * if this number is too high you're limiting the parallel processing opportunity
+     * if this number is too low you're using your resources inefficiently
+     * as every job processing has a fixed overhead which adds up if there are too many jobs
+     *
+     * in case you project is complex and you are struggling to find the correct number
+     * it's possible to move this value to a CMS setting and adjust as needed without the need of changing the code
+     * use @see Job::getUrlsPerJob() to override the value lookup
+     * you can subclass your jobs and implement your own getUrlsPerJob() method which will look into CMS setting
+     *
+     * batching capability can be disabled if urls per job is set to 0
+     * in such case, all URLs will be put into one job
+     *
+     * @var int
+     * @config
+     */
+    private static $urls_per_job = 0;
+
+    /**
+     * Number of URLs processed during one call of @see AbstractQueuedJob::process
+     * this number should be set to a value which represents number of URLs which is reasonable to process in one go
+     * this number will vary depending on project, more specifically it depends on:
+     * - time to render your pages
+     * - infrastructure
+     *
+     * if this number is too large jobs may experience performance / memory issues
+     * if this number is too low the jobs will produce more overhead which may cause inefficiencies
+     *
+     * in case you project is complex and you are struggling to find the correct number
+     * it's possible to move this value to a CMS setting and adjust as needed without the need of changing the code
+     * use @see Job::getChunkSize() to override the value lookup
+     * you can subclass your jobs and implement your own getChunkSize() method which will look into CMS setting
+     *
+     * chunking capability can be disabled if chunk size is set to 0
+     * in such case, all URLs will be processed in one go
+     *
      * @var int
      * @config
      */
     private static $chunk_size = 200;
 
+    public function getRunAsMemberID()
+    {
+        // static cache manipulation jobs need to run without a user
+        // this is because we don't want any session related data to become part of URLs
+        // for example stage GET param is injected into URLs when user is logged in
+        // this is problematic as stage param must not be present in statically published URLs
+        // as they always refer to live content
+        // including stage param in visiting URL is meant to bypass static cache and redirect to admin login
+        // this is something we definitely don't want for statically cached pages
+        return 0;
+    }
+
+    /**
+     * Set totalSteps to reflect how many URLs need to be processed
+     * note that chunk size may change during runtime (if CMS setting override is used)
+     * therefore it's much more accurate and useful to keep track of number of completed URLs
+     * as opposed to completed chunks
+     */
     public function setup()
     {
         parent::setup();
-        $this->totalSteps = ceil(count($this->URLsToProcess) / self::config()->get('chunk_size'));
+        $this->totalSteps = count($this->jobData->URLsToProcess);
     }
 
     public function getSignature()
     {
         return md5(implode('-', [static::class, implode('-', array_keys($this->URLsToProcess))]));
+    }
+
+    public function process()
+    {
+        $chunkSize = $this->getChunkSize();
+        $count = 0;
+        foreach ($this->jobData->URLsToProcess as $url => $priority) {
+            $count += 1;
+            if ($chunkSize > 0 && $count > $chunkSize) {
+                break;
+            }
+
+            $this->processUrl($url, $priority);
+        }
+
+        $this->updateCompletedState();
+    }
+
+    /**
+     * Generate static cache related jobs from data
+     *
+     * @param array $urls URLs to be processed into jobs
+     * @param string $message will be stored in job data and it's useful debug information
+     * @param int|null $urlsPerJob number of URLs per job, defaults to Job specific configuration
+     * @param string|null $jobClass job class used to create jobs, defaults to current class
+     * @return array|Job[]
+     */
+    public function createJobsFromData(
+        array $urls,
+        $message = '',
+        $urlsPerJob = null,
+        $jobClass = null
+    ) {
+        if (count($urls) === 0) {
+            return [];
+        }
+
+        // remove duplicate URLs
+        $urls = array_unique($urls);
+
+        // fall back to current job class if we don't have an explicit value set
+        if ($jobClass === null) {
+            $jobClass = static::class;
+        }
+
+        // validate job class
+        $job = singleton($jobClass);
+        if (!($job instanceof Job)) {
+            throw new ValidationException(
+                sprintf('Invalid job class %s, expected instace of %s', get_class($job), Job::class)
+            );
+        }
+
+        // fall back to current job urls_per_job if we don't have an explicit value set
+        if ($urlsPerJob === null) {
+            $urlsPerJob = $job->getUrlsPerJob();
+        }
+
+        // if no message is provided don't include it
+        $message = (strlen($message) > 0) ? $message . ': ' : '';
+
+        // batch URLs
+        $batches = ($urlsPerJob > 0) ? array_chunk($urls, $urlsPerJob) : [$urls];
+
+        $jobs = [];
+        foreach ($batches as $urls) {
+            // sanitise the URLS
+            $urlService = Injector::inst()->create(URLSanitisationService::class);
+            $urlService->addURLs($urls);
+            $urls = $urlService->getURLs(true);
+
+            // create job and populate it with data
+            $job = Injector::inst()->create($jobClass);
+            $jobData = new stdClass();
+            $jobData->URLsToProcess = $urls;
+
+            $job->setJobData(count($jobData->URLsToProcess), 0, false, $jobData, [
+                $message . var_export(array_keys($jobData->URLsToProcess), true),
+            ]);
+
+            $jobs[] = $job;
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * Generate and queue static cache related jobs from data
+     *
+     * @param array $urls URLs to be processed into jobs
+     * @param string $message will be stored in job data and it's useful debug information
+     * @param int|null $urlsPerJob number of URLs per job, defaults to Job specific configuration
+     * @param string|null $jobClass job class used to create jobs, defaults to current class
+     */
+    public function queueJobsFromData(
+        array $urls,
+        $message = '',
+        $urlsPerJob = null,
+        $jobClass = null
+    ) {
+        $jobs = $this->createJobsFromData($urls, $message, $urlsPerJob, $jobClass);
+
+        // default queue process
+        $service = QueuedJobService::singleton();
+
+        foreach ($jobs as $job) {
+            $service->queueJob($job);
+        }
+    }
+
+    /**
+     * Implement this method to process URL
+     *
+     * @param string $url
+     * @param int $priority
+     */
+    abstract protected function processUrl($url, $priority);
+
+    /**
+     * Move URL to list of processed URLs and update job step to indicate progress
+     * indication of progress is important for jobs which take long time to process
+     * jobs that do not indicate progress may be identified as stalled by the queue
+     * and may end up paused
+     *
+     * @param string $url
+     */
+    protected function markUrlAsProcessed($url)
+    {
+        $this->jobData->ProcessedURLs[$url] = $url;
+        unset($this->jobData->URLsToProcess[$url]);
+        $this->currentStep += 1;
+    }
+
+    /**
+     * Check if job is complete and update the job state if needed
+     */
+    protected function updateCompletedState()
+    {
+        if (count($this->jobData->URLsToProcess) > 0) {
+            return;
+        }
+
+        $this->isComplete = true;
+    }
+
+    /**
+     * @return int
+     */
+    protected function getUrlsPerJob()
+    {
+        $urlsPerJob = (int) $this->config()->get('urls_per_job');
+
+        return ($urlsPerJob > 0) ? $urlsPerJob : 0;
+    }
+
+    /**
+     * @return int
+     */
+    protected function getChunkSize()
+    {
+        $chunkSize = (int) $this->config()->get('chunk_size');
+
+        return ($chunkSize > 0) ? $chunkSize : 0;
+    }
+
+    /**
+     * This function can be overridden to handle the case of failure of specific URL processing
+     * such case is not handled by default which results in all such errors being effectively silenced
+     *
+     * @param string $url
+     * @param array $meta
+     */
+    protected function handleFailedUrl($url, array $meta)
+    {
+        // no op
     }
 }

--- a/src/Job/DeleteStaticCacheJob.php
+++ b/src/Job/DeleteStaticCacheJob.php
@@ -5,6 +5,12 @@ namespace SilverStripe\StaticPublishQueue\Job;
 use SilverStripe\StaticPublishQueue\Job;
 use SilverStripe\StaticPublishQueue\Publisher;
 
+/**
+ * Class DeleteStaticCacheJob
+ * remove pages from static cache based on list of URLs
+ *
+ * @package SilverStripe\StaticPublishQueue\Job
+ */
 class DeleteStaticCacheJob extends Job
 {
     /**
@@ -22,22 +28,19 @@ class DeleteStaticCacheJob extends Job
     }
 
     /**
-     * Do some processing yourself!
+     * @param string $url
+     * @param int $priority
      */
-    public function process()
+    protected function processUrl($url, $priority)
     {
-        $chunkSize = self::config()->get('chunk_size');
-        $count = 0;
-        foreach ($this->jobData->URLsToProcess as $url => $priority) {
-            if (++$count > $chunkSize) {
-                break;
-            }
-            $meta = Publisher::singleton()->purgeURL($url);
-            if (!empty($meta['success'])) {
-                $this->jobData->ProcessedURLs[$url] = $url;
-                unset($this->jobData->URLsToProcess[$url]);
-            }
+        $meta = Publisher::singleton()->purgeURL($url);
+        $meta = (is_array($meta)) ? $meta : [];
+        if (array_key_exists('success', $meta) && $meta['success']) {
+            $this->markUrlAsProcessed($url);
+
+            return;
         }
-        $this->isComplete = empty($this->jobData->URLsToProcess);
+
+        $this->handleFailedUrl($url, $meta);
     }
 }

--- a/src/Service/URLSanitisationService.php
+++ b/src/Service/URLSanitisationService.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace SilverStripe\StaticPublishQueue\Service;
+
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Injector\Injectable;
+
+/**
+ * Class URLSanitisationService
+ * Provides an abstraction for populating and generating a list of
+ * URLs to be cached by StaticPublishQueue.
+ *
+ * @package SilverStripe\StaticPublishQueue\Service
+ */
+class URLSanitisationService
+{
+    use Configurable;
+    use Injectable;
+
+    /**
+     * Enable to force all URLs to be changed to https
+     *
+     * @var bool
+     * @config
+     */
+    private static $force_ssl = false;
+
+    /**
+     * @var array
+     */
+    private $urls = [];
+
+    /**
+     * @var int
+     */
+    private $pointer = 0;
+
+    /**
+     * @param string $url
+     */
+    public function addURL(string $url): void
+    {
+        $url = $this->enforceTrailingSlash($url);
+        $url = $this->enforceSSL($url);
+
+        // Check if this URL is already represented.
+        if (array_key_exists($url, $this->urls)) {
+            // Don't need to add it again if it is.
+            return;
+        }
+
+        $this->urls[$url] = $this->pointer;
+        $this->pointer += 1;
+    }
+
+    /**
+     * @param array $urls
+     */
+    public function addURLs(array $urls): void
+    {
+        foreach ($urls as $url) {
+            $this->addURL($url);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getURLs(bool $formatted = false): array
+    {
+        if ($formatted) {
+            return $this->urls;
+        }
+
+        return array_keys($this->urls);
+    }
+
+    /**
+     * Make sure we don't have multiple variations of the same URL (with and without trailing slash)
+     *
+     * @param string $url
+     * @return string
+     */
+    protected function enforceTrailingSlash(string $url): string
+    {
+        $query = parse_url($url, PHP_URL_QUERY);
+        $queryString = strlen($query) > 0
+            ? '?' . $query
+            : '';
+
+        $url = str_replace('?' . $query, '', $url);
+        $url = rtrim($url, '/') . '/';
+
+        return $url . $queryString;
+    }
+
+    /**
+     * Force SSL if needed
+     *
+     * @param string $url
+     * @return string
+     */
+    protected function enforceSSL(string $url): string
+    {
+        $forceSSL = $this->getForceSSL();
+        if (!$forceSSL) {
+            return $url;
+        }
+
+        return str_replace('http://', 'https://', $url);
+    }
+
+    /**
+     * Override this function if runtime change is needed (CMS setting or Environment variable)
+     *
+     * @return bool
+     */
+    protected function getForceSSL(): bool
+    {
+        return (bool) $this->config()->get('force_ssl');
+    }
+}

--- a/tests/php/JobTest.php
+++ b/tests/php/JobTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace SilverStripe\StaticPublishQueue\Test;
+
+use ReflectionException;
+use ReflectionMethod;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\StaticPublishQueue\Job;
+use SilverStripe\StaticPublishQueue\Job\DeleteStaticCacheJob;
+use SilverStripe\StaticPublishQueue\Job\GenerateStaticCacheJob;
+use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
+
+/**
+ * Class JobTest
+ *
+ * @package SilverStripe\StaticPublishQueue\Test
+ */
+class JobTest extends SapphireTest
+{
+    /**
+     * @var bool
+     */
+    protected $usesDatabase = true;
+
+    public function testJobsFromDataDefault(): void
+    {
+        $urls = [
+            'http://some-locale/some-page/',
+            'http://some-locale/some-other-page/',
+        ];
+
+        GenerateStaticCacheJob::singleton()->queueJobsFromData($urls);
+
+        $jobs = QueuedJobDescriptor::get()->filter(['Implementation' => GenerateStaticCacheJob::class]);
+        $this->assertCount(1, $jobs);
+
+        /** @var QueuedJobDescriptor $jobDescriptor */
+        $jobDescriptor = $jobs->first();
+        $savedJobData = unserialize($jobDescriptor->SavedJobData);
+
+        $this->assertEquals([
+            'http://some-locale/some-page/' => 0,
+            'http://some-locale/some-other-page/' => 1,
+
+        ], $savedJobData->URLsToProcess);
+    }
+
+    /**
+     * @param string $jobClass
+     * @dataProvider jobClasses
+     */
+    public function testJobsFromDataJobClass(string $jobClass): void
+    {
+        $urls = [
+            'http://some-locale/some-page/',
+            'http://some-locale/some-other-page/',
+        ];
+
+        GenerateStaticCacheJob::singleton()->queueJobsFromData($urls, '', null, $jobClass);
+
+        $jobs = QueuedJobDescriptor::get()->filter(['Implementation' => $jobClass]);
+        $this->assertCount(1, $jobs);
+    }
+
+    public function testJobsFromDataMessage(): void
+    {
+        $urls = [
+            'http://some-locale/some-page/',
+            'http://some-locale/some-other-page/',
+        ];
+
+        $message = 'test message';
+
+        GenerateStaticCacheJob::singleton()->queueJobsFromData($urls, $message);
+
+        $jobs = QueuedJobDescriptor::get()->filter(['Implementation' => GenerateStaticCacheJob::class]);
+        $this->assertCount(1, $jobs);
+
+        /** @var QueuedJobDescriptor $jobDescriptor */
+        $jobDescriptor = $jobs->first();
+        $savedJobMessages = unserialize($jobDescriptor->SavedJobMessages);
+        $this->assertCount(1, $savedJobMessages);
+
+        $messageData = array_shift($savedJobMessages);
+        $this->assertContains($message, $messageData);
+    }
+
+    public function testJobsFromDataExplicitUrlsPerJob(): void
+    {
+        $urls = [
+            'http://some-locale/some-page/',
+            'http://some-locale/some-other-page/',
+        ];
+
+        GenerateStaticCacheJob::singleton()->queueJobsFromData($urls, '', 1);
+
+        $jobs = QueuedJobDescriptor::get()->filter(['Implementation' => GenerateStaticCacheJob::class]);
+        $this->assertCount(2, $jobs);
+    }
+
+    public function testJobsFromDataImplicitUrlsPerJob(): void
+    {
+        Config::modify()->set(GenerateStaticCacheJob::class, 'urls_per_job', 1);
+        $urls = [
+            'http://some-locale/some-page/',
+            'http://some-locale/some-other-page/',
+        ];
+
+        GenerateStaticCacheJob::singleton()->queueJobsFromData($urls);
+
+        $jobs = QueuedJobDescriptor::get()->filter(['Implementation' => GenerateStaticCacheJob::class]);
+        $this->assertCount(2, $jobs);
+    }
+
+    public function testJobsFromDataQueueCallback(): void
+    {
+        $urls = [
+            'http://some-locale/some-page/',
+            'http://some-locale/some-other-page/',
+        ];
+
+        $jobs = GenerateStaticCacheJob::singleton()->createJobsFromData($urls);
+
+        $this->assertCount(1, $jobs);
+
+        $job = array_shift($jobs);
+        $this->assertInstanceOf(GenerateStaticCacheJob::class, $job);
+
+        $this->assertCount(
+            0,
+            QueuedJobDescriptor::get()->filter(['Implementation' => GenerateStaticCacheJob::class])
+        );
+    }
+
+    /**
+     * @param string $jobClass
+     * @param int $urlsPerJob
+     * @throws ReflectionException
+     * @dataProvider urlsPerJobCases
+     */
+    public function testUrlsPerJob(string $jobClass, int $urlsPerJob): void
+    {
+        Config::modify()->set($jobClass, 'urls_per_job', $urlsPerJob);
+
+        /** @var Job $job */
+        $job = singleton($jobClass);
+
+        $method = new ReflectionMethod(Job::class, 'getUrlsPerJob');
+        $method->setAccessible(true);
+        $this->assertEquals($urlsPerJob, $method->invoke($job));
+    }
+
+    /**
+     * @param string $jobClass
+     * @param int $chunkSize
+     * @throws ReflectionException
+     * @dataProvider chunkCases
+     */
+    public function testChunkSize(string $jobClass, int $chunkSize): void
+    {
+        Config::modify()->set($jobClass, 'chunk_size', $chunkSize);
+
+        /** @var Job $job */
+        $job = singleton($jobClass);
+
+        $method = new ReflectionMethod(Job::class, 'getChunkSize');
+        $method->setAccessible(true);
+        $this->assertEquals($chunkSize, $method->invoke($job));
+    }
+
+    /**
+     * @return array
+     */
+    public function jobClasses(): array
+    {
+        return [
+            [GenerateStaticCacheJob::class],
+            [DeleteStaticCacheJob::class],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function urlsPerJobCases(): array
+    {
+        return [
+            [
+                GenerateStaticCacheJob::class,
+                8,
+            ],
+            [
+                DeleteStaticCacheJob::class,
+                9,
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function chunkCases(): array
+    {
+        return [
+            [
+                GenerateStaticCacheJob::class,
+                10,
+            ],
+            [
+                DeleteStaticCacheJob::class,
+                15,
+            ],
+        ];
+    }
+}

--- a/tests/php/URLSanitisationServiceTest.php
+++ b/tests/php/URLSanitisationServiceTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace SilverStripe\StaticPublishQueue\Test;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\StaticPublishQueue\Service\URLSanitisationService;
+
+/**
+ * Class URLSanitisationServiceTest
+ *
+ * @package SilverStripe\StaticPublishQueue\Test
+ */
+class URLSanitisationServiceTest extends SapphireTest
+{
+    /**
+     * @param bool $formatted
+     * @param array $urls
+     * @param array $expected
+     * @dataProvider formattedUrlsProvider
+     */
+    public function testFormatting($formatted, array $urls, array $expected)
+    {
+        $urlsService = URLSanitisationService::create();
+        $urlsService->addURLs($urls);
+        $urls = $urlsService->getURLs($formatted);
+
+        $this->assertEquals($expected, $urls);
+    }
+
+    /**
+     * @param bool $ssl
+     * @param array $urls
+     * @param array $expected
+     * @dataProvider transformationUrlsProvider
+     */
+    public function testTransformation($ssl, array $urls, array $expected)
+    {
+        if ($ssl) {
+            Config::modify()->set(URLSanitisationService::class, 'force_ssl', true);
+        }
+
+        // normal transformation (protocol change)
+        $urlsService = URLSanitisationService::create();
+        $urlsService->addURLs($urls);
+        $urls = $urlsService->getURLs();
+
+        $this->assertEquals($expected, $urls);
+
+        $urlsService = URLSanitisationService::create();
+        $urlsService->addURLs($urls);
+        $this->assertEquals($expected, $urlsService->getURLs());
+    }
+
+    public function transformationUrlsProvider()
+    {
+        return [
+            [
+                // protocol change
+                false,
+                [
+                    'http://some-locale/some-page/',
+                ],
+                [
+                    'http://some-locale/some-page/',
+                ],
+            ],
+            [
+                // protocol change
+                true,
+                [
+                    'http://some-locale/some-page/',
+                ],
+                [
+                    'https://some-locale/some-page/',
+                ],
+            ],
+            [
+                // enforce trailing slash
+                false,
+                [
+                    'http://some-locale/some-page',
+                ],
+                [
+                    'http://some-locale/some-page/',
+                ],
+            ],
+            [
+                // enforce trailing slash
+                true,
+                [
+                    'http://some-locale/some-page',
+                ],
+                [
+                    'https://some-locale/some-page/',
+                ],
+            ],
+        ];
+    }
+
+    public function formattedUrlsProvider()
+    {
+        return [
+            [
+                false,
+                [
+                    'http://some-locale/some-page/',
+                    'http://some-locale/some-other-page/',
+                ],
+                [
+                    'http://some-locale/some-page/',
+                    'http://some-locale/some-other-page/',
+                ]
+            ],
+            [
+                true,
+                [
+                    'http://some-locale/some-page/',
+                    'http://some-locale/some-other-page/',
+                ],
+                [
+                    'http://some-locale/some-page/' => 0,
+                    'http://some-locale/some-other-page/' => 1,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Configuration / extensibility improvements

* Added new options for configuration/extensibility
* changes are backward-compatible (default setup has the same behavior as before)

## Features

###  URLSanitisationService

* provides a clean way to sanitize URLs before passing these URLs to job data
* options for this service:
* `force_ssl` - force all URLs to be changed to https
* format URLs into a structure which is used in the job data

### queueJobsFromData / createJobsFromData 

* This method acts as a factory to generate jobs from provided data
* following data can be provided:
* URLs (will get sanitized automatically)
* job class (determine what type of jobs will get produced)
* number of URLs per job
* job data message (mostly useful for debugging)

### job processing

* jobs now utilize the `currentStep` feature of the queued jobs to indicate the job progress
* `totalSteps` of the job now represents the number of URLs to process instead of the number of chunks as chunk size can change during runtime
* added an option to handle failed URL processing via the `handleFailedUrl` method

### configuration

* `urls_per_job` determines how many URLs are put into one job
* This configuration can be set to a job type (inherited in a standard way)
* alternatively, this configuration can be changed during runtime by either overriding the method on job class or explicitly passing urls_per_job to the `queueJobsFromData` method
* `chunk_size` configuration can be changed during runtime by overriding the method on job class

## Other changes

* Minimum PHP version bumped up to `7.1`
* Travis config updated
* Minor code cleanup and linting changes

## Related issues

https://github.com/silverstripe/silverstripe-staticpublishqueue/issues/107