### PR TITLE
Bugfix/domain based caching

### DIFF
--- a/docs/en/basic_configuration.md
+++ b/docs/en/basic_configuration.md
@@ -1,7 +1,7 @@
 # Basic Configuration
 
-By default, the extensions `SiteTreePublishingEngine` and `PublishableSiteTree` 
-are applied to `SiteTree`, so as soon as the module is installed, it should 
+By default, the extensions `SiteTreePublishingEngine` and `PublishableSiteTree`
+are applied to `SiteTree`, so as soon as the module is installed, it should
 be ready to go.
 
 You'll need to configure a cron job or equivalent to process the queue (if you haven't already):
@@ -12,8 +12,8 @@ You'll need to configure a cron job or equivalent to process the queue (if you h
 
 Which will ensure that the `GenerateStaticCacheJob`s are processed quickly.
 
-Without further configuration, your site won't serve the static cache files. 
-See [handling requests](handling_requests.md) for details on how to 
+Without further configuration, your site won't serve the static cache files.
+See [handling requests](handling_requests.md) for details on how to
 make sure you are passing through to the statically cached files.
 
 Out of the box, the publisher will create a simple `.php` file, which contains
@@ -39,7 +39,7 @@ By default, all pages which inherit from `SiteTree` will be included in the stat
 You can exclude pages from being statically generated on a class-by-class basis by adding a `urlsToCache()` method to your page class which returns an empty array:
 
 ```php
-class MyFormPage extends Page 
+class MyFormPage extends Page
 {
 
     public function urlsToCache() {
@@ -58,8 +58,8 @@ of some change of state. An example here is a `Page` with some associated object
 trigger republishing of the `Page`, but they are not themselves published.
 
 `StaticallyPublishable` complements the trigger. It is assigned to objects which want to be statically published.
-Objects are able to claim any amount of URLs (including their own, and also any sub-urls). If you need to trigger 
-republishing or URLs assigned to another objects, implement the `StaticPublishingTrigger`. In our example of `Page` 
+Objects are able to claim any amount of URLs (including their own, and also any sub-urls). If you need to trigger
+republishing or URLs assigned to another objects, implement the `StaticPublishingTrigger`. In our example of `Page`
 with related objects, the Page would be publishable, but the objects wouldn't.
 
 Most of the time the Objects will be both acting as triggers (e.g. for themselves) and as publishable objects
@@ -90,3 +90,13 @@ SilverStripe\StaticPublishQueue\Publisher:
 ```
 
 Note: Changing this setting does not have an instant effect on the cached pages.  The timestamp will only be added/removed when the cached page is regenerated.
+
+## Forcing SSL during cache generation
+
+Add the following to your .env file:
+
+```
+SS_STATIC_FORCE_SSL="true"
+```
+
+Enabling this option means you need to force your site to use SSL. If you don't do this, the site won't load properly over plain HTTP.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -66,6 +66,9 @@ if (!function_exists('SilverStripe\\StaticPublishQueue\\PathToURL')) {
 
         if ($domainBasedCaching) {
             // factor in the domain as the top dir
+            if (substr($relativeURL, -6) === '/index') {
+                $relativeURL = substr($relativeURL, 0, strlen($relativeURL) - 5);
+            }
             return \SilverStripe\Control\Director::protocol() . $relativeURL;
         }
 

--- a/src/Job/StaticCacheFullBuildJob.php
+++ b/src/Job/StaticCacheFullBuildJob.php
@@ -80,7 +80,14 @@ class StaticCacheFullBuildJob extends Job
 
         if (count($this->URLsToProcess) === 0) {
             $trimSlashes = function ($value) {
-                return trim($value, '/');
+                $value = trim($value, '/');
+
+                // We want to trim the schema from the beginning as they map to the same place
+                // anyway.
+                $value = ltrim($value, 'http://');
+                $value = ltrim($value, 'https://');
+
+                return $value;
             };
 
             // List of all URLs which have a static cache file

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -9,6 +9,7 @@ use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\CoreKernel;
+use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -85,6 +86,11 @@ abstract class Publisher implements StaticPublisher
             SSViewer::set_themes($rawThemes);
         }
         try {
+            $ssl = Environment::getEnv('SS_STATIC_FORCE_SSL');
+            if (is_null($ssl)) {
+                $ssl = $urlParts['scheme'] == 'https' ? true : false;
+            }
+
             // try to add all the server vars that would be needed to create a static cache
             $request = HTTPRequestBuilder::createFromVariables(
                 [
@@ -92,7 +98,7 @@ abstract class Publisher implements StaticPublisher
                         'REQUEST_URI' => isset($urlParts['path']) ? $urlParts['path'] : '',
                         'REQUEST_METHOD' => 'GET',
                         'REMOTE_ADDR' => '127.0.0.1',
-                        'HTTPS' => $urlParts['scheme'] === 'https' ? 'on' : 'off',
+                        'HTTPS' => $ssl ? 'on' : 'off',
                         'QUERY_STRING' => isset($urlParts['query']) ? $urlParts['query'] : '',
                         'REQUEST_TIME' => DBDatetime::now()->getTimestamp(),
                         'REQUEST_TIME_FLOAT' => (float) DBDatetime::now()->getTimestamp(),

--- a/src/Task/StaticCacheFullBuildTask.php
+++ b/src/Task/StaticCacheFullBuildTask.php
@@ -4,6 +4,7 @@ namespace SilverStripe\StaticPublishQueue\Task;
 
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -23,7 +24,7 @@ class StaticCacheFullBuildTask extends BuildTask
      */
     public function run($request)
     {
-        $job = new StaticCacheFullBuildJob();
+        $job = Injector::inst()->create(StaticCacheFullBuildJob::class);
         $signature = $job->getSignature();
 
         // see if we already have this job in a queue


### PR DESCRIPTION
This includes a few things:
1. Fixes a bug where the index files are deleted during a full cache rebuild when using domain based caching
2. Added a simple property to force SSL caching. At the moment there's cases where you can build a cache with HTTP and when accessing over HTTPS, nothing loads (font, css, images etc.) due to insecure content. This can be the case when running on the CLI.
3. Allow dev to replace StaticCacheFullBuildJobs with their own implementation
4. Fixes a bug where currentStep is not incremented meaning that when the no. of URLs to process are greater than `chunk_size`, the job will reinitialise and start again, failing to move forward. The job is stuck in a 'waiting' state. 