### PR TITLE
Expose path to URL

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -44,3 +44,26 @@ if (!function_exists('SilverStripe\\StaticPublishQueue\\URLtoPath')) {
         return $prefix . basename($filename);
     }
 }
+
+if (!function_exists('SilverStripe\\StaticPublishQueue\\PathToURL')) {
+    function PathToURL($path, $destPath, $domainBasedCaching = false)
+    {
+        if (strpos($path, $destPath) === 0) {
+            //Strip off the full path of the cache dir from the front
+            $path = substr($path, strlen($destPath));
+        }
+
+        // Strip off the file extension and leading /
+        $relativeURL = substr($path, 0, (strrpos($path, ".")));
+        $relativeURL = ltrim($relativeURL, '/');
+
+        if ($domainBasedCaching) {
+            // factor in the domain as the top dir
+            return \SilverStripe\Control\Director::protocol() . $relativeURL;
+        }
+
+        return $relativeURL == 'index'
+            ? \SilverStripe\Control\Director::absoluteBaseURL()
+            : \SilverStripe\Control\Director::absoluteURL($relativeURL);
+    }
+}

--- a/src/Publisher/FilesystemPublisher.php
+++ b/src/Publisher/FilesystemPublisher.php
@@ -6,6 +6,7 @@ use SilverStripe\Assets\Filesystem;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\StaticPublishQueue\Publisher;
+use function SilverStripe\StaticPublishQueue\PathToURL;
 use function SilverStripe\StaticPublishQueue\URLtoPath;
 
 class FilesystemPublisher extends Publisher
@@ -196,21 +197,7 @@ class FilesystemPublisher extends Publisher
 
     protected function pathToURL($path)
     {
-        if (strpos($path, $this->getDestPath()) === 0) {
-            //Strip off the full path of the cache dir from the front
-            $path = substr($path, strlen($this->getDestPath()));
-        }
-
-        // Strip off the file extension and leading /
-        $relativeURL = substr($path, 0, (strrpos($path, ".")));
-        $relativeURL = ltrim($relativeURL, '/');
-
-        if (FilesystemPublisher::config()->get('domain_based_caching')) {
-            // factor in the domain as the top dir
-            return Director::protocol() . $relativeURL;
-        }
-
-        return $relativeURL == 'index' ? Director::absoluteBaseURL() : Director::absoluteURL($relativeURL);
+        return PathToURL($path, $this->getDestPath(), FilesystemPublisher::config()->get('domain_based_caching'));
     }
 
     public function getPublishedURLs($dir = null, &$result = [])


### PR DESCRIPTION
# Expose PathToURL function

It's quite handy to have the `PathToURL` available especially when building a better UI for static cache manipulation. We already have `URLtoPath` available, so this change-set simply exposes the `PathToURL` function as well. There should be no functional changes.

## Related issues
https://github.com/silverstripe/silverstripe-staticpublishqueue/issues/109
