### PR TITLE
BUGFIX: PHP `Notice: Undefined index: extension` if there's no file extension

### DIFF
--- a/src/Publisher/FilesystemPublisher.php
+++ b/src/Publisher/FilesystemPublisher.php
@@ -213,7 +213,7 @@ class FilesystemPublisher extends Publisher
             }
             $fullPath = $dir . DIRECTORY_SEPARATOR . $fileOrDir;
             // we know html will always be generated, this prevents double ups
-            if (is_file($fullPath) && pathinfo($fullPath)['extension'] == 'html') {
+            if (is_file($fullPath) && pathinfo($fullPath, PATHINFO_EXTENSION) == 'html') {
                 $result[] = $this->pathToURL($fullPath);
                 continue;
             }


### PR DESCRIPTION
Updating to use PATHINFO_EXTENSION as this doesn't `Notice` if there's no extension.

Ref; https://www.php.net/manual/en/function.pathinfo.php#example-2967