### PR TITLE
StaticCacheFullBuildJob: Increment current step after chunk

### DIFF
--- a/src/Job/StaticCacheFullBuildJob.php
+++ b/src/Job/StaticCacheFullBuildJob.php
@@ -66,6 +66,8 @@ class StaticCacheFullBuildJob extends Job
                 unset($this->jobData->URLsToProcess[$url]);
             }
         }
+        $this->currentStep++;
+
         if (empty($this->jobData->URLsToProcess)) {
             $trimSlashes = function ($value) {
                 return trim($value, '/');


### PR DESCRIPTION
Chunking doesn't currently work because the current step is not incremented after completing a chunk. QueuedJobs interprents this as a failure and retries the chunk instead; then after a number of retries considers the job stalled.

Incrementing the current step after completing a chunk fixes this and resolve #103.