### PR TITLE
Fix base URL to respect custom port

### DIFF
--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -88,7 +88,7 @@ abstract class Publisher implements StaticPublisher
                         'QUERY_STRING' => isset($urlParts['query']) ? $urlParts['query'] : '',
                         'REQUEST_TIME' => DBDatetime::now()->getTimestamp(),
                         'REQUEST_TIME_FLOAT' => (float) DBDatetime::now()->getTimestamp(),
-                        'HTTP_HOST' => $urlParts['host'],
+                        'HTTP_HOST' => $urlParts['host'] . (isset($urlParts['port']) ? ':' . $urlParts['port'] : ''),
                         'HTTP_USER_AGENT' => 'silverstripe/staticpublishqueue',
                     ],
                     '_GET' => $getVars,


### PR DESCRIPTION
This was not respecting the port part of a host when generating files, e.g. with a .env base URL like:
`SS_BASE_URL='http://localhost:8080'`

In the resulting html the `<% base_tag %>` would output:
`<base href="http://localhost/">`
Which would break URLs and CSP etc.