### PR TITLE
Extensibility enhancements. DRY code cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ It generates the cache files using the [QueuedJobs module](https://github.com/sy
 * "silverstripe/framework": "^4.0.2",
 * "silverstripe/cms": "^4",
 * "silverstripe/config": "^1",
-* "symbiote/silverstripe-queuedjobs": "^4.0.6",
+* "symbiote/silverstripe-queuedjobs": "^4.5",
 * "silverstripe/versioned": "^1.0.2"

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,11 @@
         "publishing"
     ],
     "require": {
+        "php": "^7.1",
         "silverstripe/framework": "^4.0.2",
         "silverstripe/cms": "^4",
         "silverstripe/config": "^1",
-        "symbiote/silverstripe-queuedjobs": "^4.0.6",
+        "symbiote/silverstripe-queuedjobs": "^4.5",
         "silverstripe/versioned": "^1.0.2"
     },
     "require-dev": {

--- a/src/Job.php
+++ b/src/Job.php
@@ -6,25 +6,142 @@ use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extensible;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 
+/**
+ * Class Job
+ *
+ * @property array $URLsToProcess
+ * @property array $ProcessedURLs
+ * @package SilverStripe\StaticPublishQueue
+ */
 abstract class Job extends AbstractQueuedJob
 {
     use Configurable;
     use Extensible;
 
     /**
+     * Number of URLs processed during one call of @see AbstractQueuedJob::process()
+     * this number should be set to a value which represents number of URLs which is reasonable to process in one go
+     * this number will vary depending on project, more specifically it depends on:
+     * - time to render your pages
+     * - infrastructure
+     *
+     * if this number is too large jobs may experience performance / memory issues
+     * if this number is too low the jobs will produce more overhead which may cause inefficiencies
+     *
+     * in case you project is complex and you are struggling to find the correct number
+     * it's possible to move this value to a CMS setting and adjust as needed without the need of changing the code
+     * use @see Job::getChunkSize() to override the value lookup
+     * you can subclass your jobs and implement your own getChunkSize() method which will look into CMS setting
+     *
+     * chunking capability can be disabled if chunk size is set to 0
+     * in such case, all URLs will be processed in one go
+     *
      * @var int
      * @config
      */
     private static $chunk_size = 200;
 
-    public function setup()
+    /**
+     * Static cache manipulation jobs need to run without a user
+     * this is because we don't want any session related data to become part of URLs
+     * For example stage GET param is injected into URLs when user is logged in
+     * This is problematic as stage param must not be present in statically published URLs
+     * as they always refer to live content
+     * Including stage param in visiting URL is meant to bypass static cache and redirect to admin login
+     * this is something we definitely don't want for statically cached pages
+     *
+     * @return int|null
+     */
+    public function getRunAsMemberID(): ?int
     {
-        parent::setup();
-        $this->totalSteps = ceil(count($this->URLsToProcess) / self::config()->get('chunk_size'));
+        return 0;
     }
 
-    public function getSignature()
+    public function setup(): void
+    {
+        parent::setup();
+        $this->totalSteps = count($this->URLsToProcess);
+    }
+
+    public function getSignature(): string
     {
         return md5(implode('-', [static::class, implode('-', array_keys($this->URLsToProcess))]));
+    }
+
+    public function process(): void
+    {
+        $chunkSize = $this->getChunkSize();
+        $count = 0;
+
+        foreach ($this->URLsToProcess as $url => $priority) {
+            $count += 1;
+
+            if ($chunkSize > 0 && $count > $chunkSize) {
+                return;
+            }
+
+            $this->processUrl($url, $priority);
+        }
+
+        $this->updateCompletedState();
+    }
+
+    /**
+     * Implement this method to process URL
+     *
+     * @param string $url
+     * @param int $priority
+     */
+    abstract protected function processUrl(string $url, int $priority): void;
+
+    /**
+     * Move URL to list of processed URLs and update job step to indicate progress
+     * indication of progress is important for jobs which take long time to process
+     * jobs that do not indicate progress may be identified as stalled by the queue
+     * and may end up paused
+     *
+     * @param string $url
+     */
+    protected function markUrlAsProcessed(string $url): void
+    {
+        // These operation has to be done directly on the job data properties
+        // as the magic methods won't cover array access write
+        $this->jobData->ProcessedURLs[$url] = $url;
+        unset($this->jobData->URLsToProcess[$url]);
+        $this->currentStep += 1;
+    }
+
+    /**
+     * Check if job is complete and update the job state if needed
+     */
+    protected function updateCompletedState(): void
+    {
+        if (count($this->URLsToProcess) > 0) {
+            return;
+        }
+
+        $this->isComplete = true;
+    }
+
+    /**
+     * @return int
+     */
+    protected function getChunkSize(): int
+    {
+        $chunkSize = (int) $this->config()->get('chunk_size');
+
+        return $chunkSize > 0 ? $chunkSize : 0;
+    }
+
+    /**
+     * This function can be overridden to handle the case of failure of specific URL processing
+     * such case is not handled by default which results in all such errors being effectively silenced
+     *
+     * @param string $url
+     * @param array $meta
+     */
+    protected function handleFailedUrl(string $url, array $meta)
+    {
+        // no op - override this on your job classes if needed
     }
 }

--- a/src/Job/GenerateStaticCacheJob.php
+++ b/src/Job/GenerateStaticCacheJob.php
@@ -5,34 +5,37 @@ namespace SilverStripe\StaticPublishQueue\Job;
 use SilverStripe\StaticPublishQueue\Job;
 use SilverStripe\StaticPublishQueue\Publisher;
 
+/**
+ * Class GenerateStaticCacheJob
+ * add pages to static cache based on list of URLs
+ *
+ * @package SilverStripe\StaticPublishQueue\Job
+ */
 class GenerateStaticCacheJob extends Job
 {
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return 'Generate a set of static pages from URLs';
     }
 
     /**
-     * Do some processing yourself!
+     * @param string $url
+     * @param int $priority
      */
-    public function process()
+    protected function processUrl(string $url, int $priority): void
     {
-        $chunkSize = self::config()->get('chunk_size');
-        $count = 0;
-        foreach (array_keys($this->jobData->URLsToProcess) as $url) {
-            if (++$count > $chunkSize) {
-                break;
-            }
-            $meta = Publisher::singleton()->publishURL($url, true);
-            if (!empty($meta['success'])) {
-                $this->jobData->ProcessedURLs[$url] = $url;
-                unset($this->jobData->URLsToProcess[$url]);
-            }
+        $meta = Publisher::singleton()->publishURL($url, true);
+        $meta = is_array($meta) ? $meta : [];
+
+        if (array_key_exists('success', $meta) && $meta['success']) {
+            $this->markUrlAsProcessed($url);
+
+            return;
         }
-        $this->currentStep++;
-        $this->isComplete = empty($this->jobData->URLsToProcess);
+
+        $this->handleFailedUrl($url, $meta);
     }
 }


### PR DESCRIPTION
# Configuration / extensibility improvements

* Added new options for configuration/extensibility
* Code made more DRY and extensible
* Documentation added
* Changes are backward-compatible (default setup has the same behaviour as before)

## Features

### configuration

* `chunk_size` configuration can be changed during runtime by overriding the method on job class

## Other changes

* Minimum PHP version bumped up to `7.1`
* Minor code cleanup and linting changes

## Related issues

https://github.com/silverstripe/silverstripe-staticpublishqueue/issues/107