### PR TITLE
NEW: Static cache batching improvements.

### DIFF
--- a/_config/staticpublishqueue.yml
+++ b/_config/staticpublishqueue.yml
@@ -8,6 +8,8 @@ SilverStripe\Core\Injector\Injector:
     properties:
       States:
         staticPublisherState: '%$SilverStripe\StaticPublishQueue\Dev\StaticPublisherState'
+  SilverStripe\StaticPublishQueue\Service\UrlBundleInterface:
+    class: SilverStripe\StaticPublishQueue\Service\UrlBundleService
 SilverStripe\CMS\Model\SiteTree:
   extensions:
     - SilverStripe\StaticPublishQueue\Extension\Engine\SiteTreePublishingEngine

--- a/src/Extension/Engine/SiteTreePublishingEngine.php
+++ b/src/Extension/Engine/SiteTreePublishingEngine.php
@@ -103,7 +103,6 @@ class SiteTreePublishingEngine extends SiteTreeExtension implements Resettable
 
     /**
      * @param SiteTree|SiteTreePublishingEngine|null $original
-     * @throws ValidationException
      */
     public function onAfterPublishRecursive(&$original)
     {
@@ -111,7 +110,7 @@ class SiteTreePublishingEngine extends SiteTreeExtension implements Resettable
         // then this is the equivalent of an un-publish and publish as far as the
         // static publisher is concerned
         if ($original && (
-            (int) $original->ParentID !== (int) $this->getOwner()->ParentID
+            $original->ParentID !== $this->getOwner()->ParentID
                 || $original->URLSegment !== $this->getOwner()->URLSegment
             )
         ) {
@@ -136,9 +135,6 @@ class SiteTreePublishingEngine extends SiteTreeExtension implements Resettable
         $this->collectChanges($context);
     }
 
-    /**
-     * @throws ValidationException
-     */
     public function onAfterUnpublish()
     {
         $this->flushChanges();
@@ -167,13 +163,12 @@ class SiteTreePublishingEngine extends SiteTreeExtension implements Resettable
 
     /**
      * Execute URL deletions, enqueue URL updates.
-     * @throws ValidationException
      */
     public function flushChanges()
     {
         $queueService = static::$queueService ?? QueuedJobService::singleton();
 
-        if (count($this->toUpdate) > 0) {
+        if (!empty($this->toUpdate)) {
             /** @var UrlBundleInterface $urlService */
             $urlService = Injector::inst()->create(UrlBundleInterface::class);
 
@@ -193,7 +188,7 @@ class SiteTreePublishingEngine extends SiteTreeExtension implements Resettable
             $this->toUpdate = [];
         }
 
-        if (count($this->toDelete) > 0) {
+        if (!empty($this->toDelete)) {
             /** @var UrlBundleInterface $urlService */
             $urlService = Injector::inst()->create(UrlBundleInterface::class);
 

--- a/src/Job.php
+++ b/src/Job.php
@@ -20,21 +20,21 @@ abstract class Job extends AbstractQueuedJob
 
     /**
      * Number of URLs processed during one call of @see AbstractQueuedJob::process()
-     * this number should be set to a value which represents number of URLs which is reasonable to process in one go
-     * this number will vary depending on project, more specifically it depends on:
+     * This number should be set to a value which represents number of URLs which is reasonable to process in one go
+     * This number will vary depending on project, more specifically it depends on:
      * - time to render your pages
      * - infrastructure
      *
-     * if this number is too large jobs may experience performance / memory issues
-     * if this number is too low the jobs will produce more overhead which may cause inefficiencies
+     * If this number is too large jobs may experience performance / memory issues
+     * If this number is too low the jobs will produce more overhead which may cause inefficiencies
      *
-     * in case you project is complex and you are struggling to find the correct number
-     * it's possible to move this value to a CMS setting and adjust as needed without the need of changing the code
-     * use @see Job::getChunkSize() to override the value lookup
-     * you can subclass your jobs and implement your own getChunkSize() method which will look into CMS setting
+     * In case your project is complex and you are struggling to find the correct number
+     * It's possible to move this value to a CMS setting and adjust as needed without the need of changing the code
+     * Use @see Job::getChunkSize() to override the value lookup
+     * You can subclass your jobs and implement your own getChunkSize() method which will look into CMS setting
      *
-     * chunking capability can be disabled if chunk size is set to 0
-     * in such case, all URLs will be processed in one go
+     * Chunking capability can be disabled if chunk size is set to 0
+     * In such case, all URLs will be processed in one go
      *
      * @var int
      * @config
@@ -43,18 +43,18 @@ abstract class Job extends AbstractQueuedJob
 
     /**
      * Number of URLs per job allows you to split work into multiple smaller jobs instead of having one large job
-     * this is useful if you're running a queue setup will parallel processing or if you have too many URLs in general
-     * if this number is too high you're limiting the parallel processing opportunity
-     * if this number is too low you're using your resources inefficiently
+     * This is useful if you're running a queue setup will parallel processing or if you have too many URLs in general
+     * If this number is too high you're limiting the parallel processing opportunity
+     * If this number is too low you're using your resources inefficiently
      * as every job processing has a fixed overhead which adds up if there are too many jobs
      *
-     * in case you project is complex and you are struggling to find the correct number
-     * it's possible to move this value to a CMS setting and adjust as needed without the need of changing the code
-     * use @see Job::getUrlsPerJob() to override the value lookup
-     * you can subclass your jobs and implement your own getUrlsPerJob() method which will look into CMS setting
+     * In case your project is complex, and you are struggling to find the correct number
+     * it's possible to move this value to a CMS setting and adjust as needed without the need to change the code
+     * Use @see Job::getUrlsPerJob() to override the value lookup
+     * You can subclass your jobs and implement your own getUrlsPerJob() method which can read from the CMS setting
      *
-     * batching capability can be disabled if urls per job is set to 0
-     * in such case, all URLs will be put into one job
+     * Batching capability can be disabled if urls per job is set to 0
+     * In this case, all URLs will be processed in a single job
      *
      * @var int
      * @config

--- a/src/Service/UrlBundleInterface.php
+++ b/src/Service/UrlBundleInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\StaticPublishQueue\Service;
+
+use SilverStripe\ORM\DataObject;
+
+interface UrlBundleInterface
+{
+    /**
+     * Add URLs to this bundle
+     *
+     * @param array $urls
+     */
+    public function addUrls(array $urls): void;
+
+    /**
+     * Package URLs into jobs
+     *
+     * @param string $jobClass
+     * @param string|null $message
+     * @param DataObject|null $contextModel
+     * @return array
+     */
+    public function getJobsForUrls(string $jobClass, ?string $message = null, ?DataObject $contextModel = null): array;
+}

--- a/src/Service/UrlBundleService.php
+++ b/src/Service/UrlBundleService.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SilverStripe\StaticPublishQueue\Service;
+
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\StaticPublishQueue\Job;
+
+/**
+ * Class UrlBundleService
+ *
+ * This service is responsible for bundling URLs which to static cache jobs
+ * Several extension points are available to allow further customisation
+ */
+class UrlBundleService implements UrlBundleInterface
+{
+    use Extensible;
+    use Injectable;
+
+    /**
+     * @var array
+     */
+    protected $urls = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function addUrls(array $urls): void
+    {
+        foreach ($urls as $url) {
+            $this->urls[$url] = $url;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getJobsForUrls(string $jobClass, ?string $message = null, ?DataObject $contextModel = null): array
+    {
+        $singleton = singleton($jobClass);
+
+        if (!$singleton instanceof Job) {
+            return [];
+        }
+
+        $urls = $this->getUrls();
+        $urlsPerJob = $singleton->getUrlsPerJob();
+        $batches = $urlsPerJob > 0 ? array_chunk($urls, $urlsPerJob) : [$urls];
+        $jobs = [];
+
+        foreach ($batches as $urlBatch) {
+            $priorityUrls = $this->assignPriorityToUrls($urlBatch);
+
+            /** @var Job $job */
+            $job = Injector::inst()->create($jobClass);
+            $job->hydrate($priorityUrls, $message);
+
+            // Use this extension point to inject some additional data into the job
+            $this->extend('updateHydratedJob', $job, $contextModel);
+
+            $jobs[] = $job;
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * Get URLs for further processing
+     *
+     * @return array
+     */
+    protected function getUrls(): array
+    {
+        $urls = [];
+
+        foreach ($this->urls as $url) {
+            $url = $this->formatUrl($url);
+
+            if (!$url) {
+                continue;
+            }
+
+            $urls[] = $url;
+        }
+
+        $urls = array_unique($urls);
+
+        // Use this extension point to change the order of the URLs if needed
+        $this->extend('updateGetUrls', $urls);
+
+        return $urls;
+    }
+
+    /**
+     * Extensibility function which allows to handle custom formatting / encoding needs for URLs
+     * Returning "falsy" value will make the URL to be skipped
+     *
+     * @param string $url
+     * @return string|null
+     */
+    protected function formatUrl(string $url): ?string
+    {
+        // Use this extension point to reformat URLs, for example encode special characters
+        $this->extend('updateFormatUrl', $url);
+
+        return $url;
+    }
+
+    /**
+     * Add priority data to URLs
+     *
+     * @param array $urls
+     * @return array
+     */
+    protected function assignPriorityToUrls(array $urls): array
+    {
+        $priority = 0;
+        $priorityUrls = [];
+
+        foreach ($urls as $url) {
+            $priorityUrls[$url] = $priority;
+            $priority += 1;
+        }
+
+        return $priorityUrls;
+    }
+}

--- a/src/Service/UrlBundleService.php
+++ b/src/Service/UrlBundleService.php
@@ -121,7 +121,7 @@ class UrlBundleService implements UrlBundleInterface
 
         foreach ($urls as $url) {
             $priorityUrls[$url] = $priority;
-            $priority += 1;
+            ++$priority;
         }
 
         return $priorityUrls;

--- a/tests/php/UrlBundleServiceTest.php
+++ b/tests/php/UrlBundleServiceTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace SilverStripe\StaticPublishQueue\Test;
+
+use ReflectionMethod;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\StaticPublishQueue\Job;
+use SilverStripe\StaticPublishQueue\Job\DeleteStaticCacheJob;
+use SilverStripe\StaticPublishQueue\Job\GenerateStaticCacheJob;
+use SilverStripe\StaticPublishQueue\Service\UrlBundleService;
+
+class UrlBundleServiceTest extends SapphireTest
+{
+    /**
+     * @param string $jobClass
+     * @dataProvider jobClasses
+     */
+    public function testJobsFromDataDefault(string $jobClass): void
+    {
+        $urls = [
+            'http://some-locale/some-page/',
+            'http://some-locale/some-other-page/',
+        ];
+        $message = 'Test message';
+
+        $service = UrlBundleService::create();
+        $service->addUrls($urls);
+        $jobs = $service->getJobsForUrls($jobClass, $message);
+
+        $this->assertCount(1, $jobs);
+
+        /** @var Job $job */
+        $job = array_shift($jobs);
+
+        $this->assertEquals([
+            'http://some-locale/some-page/' => 0,
+            'http://some-locale/some-other-page/' => 1,
+
+        ], $job->URLsToProcess);
+
+        $messages = $job->getJobData()->messages;
+        $this->assertCount(1, $messages);
+
+        $messageData = array_shift($messages);
+        $this->assertContains($message, $messageData);
+    }
+
+    /**
+     * @param string $jobClass
+     * @dataProvider jobClasses
+     */
+    public function testJobsFromDataExplicitUrlsPerJob(string $jobClass): void
+    {
+        Config::modify()->set($jobClass, 'urls_per_job', 1);
+        $urls = [
+            'http://some-locale/some-page/',
+            'http://some-locale/some-other-page/',
+        ];
+
+        $service = UrlBundleService::singleton();
+        $service->addUrls($urls);
+        $jobs = $service->getJobsForUrls($jobClass);
+
+        $this->assertCount(2, $jobs);
+    }
+
+    /**
+     * @param string $jobClass
+     * @param int $urlsPerJob
+     * @dataProvider urlsPerJobCases
+     */
+    public function testUrlsPerJob(string $jobClass, int $urlsPerJob): void
+    {
+        Config::modify()->set($jobClass, 'urls_per_job', $urlsPerJob);
+
+        /** @var Job $job */
+        $job = singleton($jobClass);
+
+        $method = new ReflectionMethod(Job::class, 'getUrlsPerJob');
+        $method->setAccessible(true);
+        $this->assertEquals($urlsPerJob, $method->invoke($job));
+    }
+
+    /**
+     * @param string $jobClass
+     * @param int $chunkSize
+     * @dataProvider chunkCases
+     */
+    public function testChunkSize(string $jobClass, int $chunkSize): void
+    {
+        Config::modify()->set($jobClass, 'chunk_size', $chunkSize);
+
+        /** @var Job $job */
+        $job = singleton($jobClass);
+
+        $method = new ReflectionMethod(Job::class, 'getChunkSize');
+        $method->setAccessible(true);
+        $this->assertEquals($chunkSize, $method->invoke($job));
+    }
+
+    /**
+     * @return array
+     */
+    public function jobClasses(): array
+    {
+        return [
+            [GenerateStaticCacheJob::class],
+            [DeleteStaticCacheJob::class],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function urlsPerJobCases(): array
+    {
+        return [
+            [
+                GenerateStaticCacheJob::class,
+                8,
+            ],
+            [
+                DeleteStaticCacheJob::class,
+                9,
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function chunkCases(): array
+    {
+        return [
+            [
+                GenerateStaticCacheJob::class,
+                10,
+            ],
+            [
+                DeleteStaticCacheJob::class,
+                15,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Static cache batching improvements / fixes

This is yet another extensibility bundle based on feedback from several projects with some light bugfixes sprinkled in.

## SiteTree re-organization fix

The condition did not properly match sometimes due to the type comparison which ended up causing unwanted purge static cache jobs.

## URL bundling

Bundling of URLs into Jobs is now handled by customisable service.

## Job batch size

It's now possible to customise how many URLs are bundled into a single job. The default setting is 0 (put all URLs into a single job). This allows larger websites to manage the batch size based on their infrastructure limits.

## Explicit hydrate method for jobs

This is just a small touch to enforce proper data when creating a new job (no functional impact).