### PR TITLE
BUG: Recursive publish hook.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,29 +19,29 @@ matrix:
   fast_finish: true
   include:
     - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=4.5.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.6.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
     - php: 7.2
-      env: DB=PGSQL RECIPE_VERSION=4.5.x-dev PHPUNIT_TEST=1
+      env: DB=PGSQL RECIPE_VERSION=4.6.x-dev PHPUNIT_TEST=1
     - php: 7.3
-      env: DB=MYSQL RECIPE_VERSION=4.5.x-dev PDO=1 PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.6.x-dev PDO=1 PHPUNIT_TEST=1
     - php: 7.4
-      env: DB=MYSQL RECIPE_VERSION=4.5.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.6.x-dev PHPUNIT_TEST=1
       addons:
         apt:
           packages:
             - libonig-dev
 
 before_script:
-# Extra $PATH
+  # Extra $PATH
   - export PATH=~/.composer/vendor/bin:$PATH
-  
+
   # Init PHP
   - phpenv rehash
   - phpenv config-rm xdebug.ini
   - export PATH=~/.composer/vendor/bin:$PATH
   - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
-# Install composer dependencies
+  # Install composer dependencies
   - composer validate
   - composer require --no-update silverstripe/recipe-cms:$RECIPE_VERSION silverstripe/recipe-testing:^1
   # Fix for running phpunit 5 on php 7.4+
@@ -50,8 +50,8 @@ before_script:
   - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
- - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests/php/ flush=1; fi
- - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
+  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests/php/ flush=1; fi
+  - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/_config/staticpublishqueue.yml
+++ b/_config/staticpublishqueue.yml
@@ -4,6 +4,10 @@ Name: staticpublishqueue
 SilverStripe\Core\Injector\Injector:
   SilverStripe\StaticPublishQueue\Publisher:
     class: SilverStripe\StaticPublishQueue\Publisher\FilesystemPublisher
+  SilverStripe\Dev\State\SapphireTestState:
+    properties:
+      States:
+        staticPublisherState: '%$SilverStripe\StaticPublishQueue\Dev\StaticPublisherState'
 SilverStripe\CMS\Model\SiteTree:
   extensions:
     - SilverStripe\StaticPublishQueue\Extension\Engine\SiteTreePublishingEngine

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     ],
     "require": {
         "php": "^7.1",
-        "silverstripe/framework": "^4.0.2",
+        "silverstripe/framework": "^4.6",
         "silverstripe/cms": "^4",
         "silverstripe/config": "^1",
         "symbiote/silverstripe-queuedjobs": "^4.5",
-        "silverstripe/versioned": "^1.0.2"
+        "silverstripe/versioned": "^1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Dev/StaticPublisherState.php
+++ b/src/Dev/StaticPublisherState.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\StaticPublishQueue\Dev;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\State\TestState;
+use SilverStripe\StaticPublishQueue\Extension\Engine\SiteTreePublishingEngine;
+use SilverStripe\StaticPublishQueue\Test\QueuedJobsTestService;
+use Symbiote\QueuedJobs\Services\QueuedJobHandler;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+use Symbiote\QueuedJobs\Tests\QueuedJobsTest\QueuedJobsTest_Handler;
+
+class StaticPublisherState implements TestState
+{
+    public function setUp(SapphireTest $test)
+    {
+        // Prepare queued jobs related functionality for unit test run
+        // Disable queue logging
+        Injector::inst()->registerService(new QueuedJobsTest_Handler(), QueuedJobHandler::class);
+
+        // Disable special actions of the queue service
+        Config::modify()->set(QueuedJobService::class, 'use_shutdown_function', false);
+
+        // It seems Injector doesn't cover all cases so we force-inject a test service which is suitable for unit tests
+        Injector::inst()->registerService(new QueuedJobsTestService(), QueuedJobService::class);
+        SiteTreePublishingEngine::setQueueService(QueuedJobService::singleton());
+    }
+
+    public function tearDown(SapphireTest $test)
+    {
+    }
+
+    public function setUpOnce($class)
+    {
+    }
+
+    public function tearDownOnce($class)
+    {
+    }
+}

--- a/tests/php/Publisher/FilesystemPublisherTest.php
+++ b/tests/php/Publisher/FilesystemPublisherTest.php
@@ -14,7 +14,6 @@ use SilverStripe\StaticPublishQueue\Extension\Publishable\PublishableSiteTree;
 use SilverStripe\StaticPublishQueue\Publisher\FilesystemPublisher;
 use SilverStripe\StaticPublishQueue\Test\StaticPublisherTest\Model\StaticPublisherTestPage;
 use SilverStripe\View\SSViewer;
-use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**
  * Tests for the {@link FilesystemPublisher} class.
@@ -41,7 +40,6 @@ class FilesystemPublisherTest extends SapphireTest
         parent::setUp();
 
         Config::modify()->set(FilesystemPublisher::class, 'domain_based_caching', false);
-        Config::modify()->set(QueuedJobService::class, 'use_shutdown_function', false);
         Config::modify()->set(Director::class, 'alternate_base_url', 'http://example.com/');
 
         $mockFSP = $this->getMockBuilder(FilesystemPublisher::class)->setMethods([

--- a/tests/php/QueuedJobsTestService.php
+++ b/tests/php/QueuedJobsTestService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SilverStripe\StaticPublishQueue\Test;
+
+use SilverStripe\Core\Resettable;
+use SilverStripe\Dev\TestOnly;
+use Symbiote\QueuedJobs\Services\QueuedJob;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+class QueuedJobsTestService extends QueuedJobService implements Resettable, TestOnly
+{
+    private $jobs = [];
+
+    public function flushJobs(): void
+    {
+        $this->jobs = [];
+    }
+
+    public function getJobs(): array
+    {
+        return $this->jobs;
+    }
+
+    /**
+     * Keep the jobs in-memory for unit test purposes (avoid writes and related actions)
+     *
+     * @param QueuedJob $job
+     * @param null $startAfter
+     * @param null $userId
+     * @param null $queueName
+     * @return int
+     */
+    public function queueJob(QueuedJob $job, $startAfter = null, $userId = null, $queueName = null)
+    {
+        $this->jobs[] = $job;
+
+        return 1;
+    }
+
+    public static function reset()
+    {
+        self::singleton()->flushJobs();
+    }
+
+    /**
+     * Skip shutdown function actions
+     */
+    public function onShutdown()
+    {
+    }
+}


### PR DESCRIPTION
# Publishing engine trigger

Publishing engine now triggers `onAfterPublishRecursive` instead of `onAfterPublish` which fixes a lot of problems when dealing with pages which contains a lot of nested models like blocks. This ensures that URL collection starts after all models in the publishRecursive batch are published.

## Related issues

https://github.com/silverstripe/silverstripe-staticpublishqueue/issues/134

## Issues with tests

Unit tests are passing but the build is failing due to some QueuedJobs related issue. This is likely some registered shutdown function which is called near the end of the test suite run. I couldn't reproduce this on my local (vanilla install).

I added some logging to see the stack trace of the exception:

```
#0 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/src/Dev/TestPdoConnector.php(14): SilverStripe\ORM\Connect\DBConnector->databaseError('Couldn't run qu...', 256, 'SELECT DISTINCT...', Array)
#1 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/silverstripe/framework/src/ORM/Connect/PDOConnector.php(417): SilverStripe\StaticPublishQueue\Dev\TestPdoConnector->databaseError('3D000-1046: No ...', 256, 'SELECT DISTINCT...', Array)
#2 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/silverstripe/framework/src/ORM/Connect/Database.php(185): SilverStripe\ORM\Connect\PDOConnector->preparedQuery('SELECT DISTINCT...', Array, 256)
#3 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/silverstripe/framework/src/ORM/Connect/Database.php(258): SilverStripe\ORM\Connect\Database->SilverStripe\ORM\Connect\{closure}('SELECT DISTINCT...')
#4 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/silverstripe/framework/src/ORM/Connect/Database.php(183): SilverStripe\ORM\Connect\Database->benchmarkQuery('SELECT DISTINCT...', Object(Closure), Array)
#5 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/silverstripe/framework/src/ORM/Connect/MySQLDatabase.php(393): SilverStripe\ORM\Connect\Database->preparedQuery('SELECT DISTINCT...', Array, 256)
#6 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/silverstripe/framework/src/ORM/DB.php(445): SilverStripe\ORM\Connect\MySQLDatabase->preparedQuery('SELECT DISTINCT...', Array, 256)
#7 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/silverstripe/framework/src/ORM/Queries/SQLExpression.php(115): SilverStripe\ORM\DB::prepared_query('SELECT DISTINCT...', Array)
#8 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/silverstripe/framework/src/ORM/DataList.php(933): SilverStripe\ORM\Queries\SQLExpression->execute()
#9 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/silverstripe/framework/src/ORM/DataList.php(971): SilverStripe\ORM\DataList->first()
#10 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/symbiote/silverstripe-queuedjobs/src/Services/QueuedJobService.php(391): SilverStripe\ORM\DataList->find('JobStatus', 'Waiting')
#11 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/symbiote/silverstripe-queuedjobs/src/Services/QueuedJobService.php(1369): Symbiote\QueuedJobs\Services\QueuedJobService->getNextPendingJob('1')
#12 /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/symbiote/silverstripe-queuedjobs/src/Services/QueuedJobService.php(1390): Symbiote\QueuedJobs\Services\QueuedJobService->processJobQueue('1')
#13 [internal function]: Symbiote\QueuedJobs\Services\QueuedJobService->onShutdown()
#14 {main}PHP Warning:  Invalid argument supplied for foreach() in /home/travis/build/silverstripe/silverstripe-staticpublishqueue/vendor/silverstripe/framework/src/ORM/DataList.php on line 933
```

Looks like despite my best effort to disable the `Symbiote\QueuedJobs\Services\QueuedJobService->onShutdown()` it's still being called. The cause for this is that there are some places where `QueuedJobService` is created via Injector which is not covered by the unit tests customisation. Just having this service is memory is enough to trigger the error as that is the default behaviour.

I was able to resolve this by forced injection approach.