### PR TITLE
BUG: Page parentage update fix.

### DIFF
--- a/src/Extension/Engine/SiteTreePublishingEngine.php
+++ b/src/Extension/Engine/SiteTreePublishingEngine.php
@@ -110,7 +110,7 @@ class SiteTreePublishingEngine extends SiteTreeExtension implements Resettable
         // then this is the equivalent of an un-publish and publish as far as the
         // static publisher is concerned
         if ($original && (
-            $original->ParentID !== $this->getOwner()->ParentID
+            $original->ParentID !== (int) $this->getOwner()->ParentID
                 || $original->URLSegment !== $this->getOwner()->URLSegment
             )
         ) {

--- a/src/Extension/Engine/SiteTreePublishingEngine.php
+++ b/src/Extension/Engine/SiteTreePublishingEngine.php
@@ -110,7 +110,8 @@ class SiteTreePublishingEngine extends SiteTreeExtension implements Resettable
         // then this is the equivalent of an un-publish and publish as far as the
         // static publisher is concerned
         if ($original && (
-            $original->ParentID !== (int) $this->getOwner()->ParentID
+            // Intentionally using loose comparison as ParentID may contain either string or integer
+            $original->ParentID != $this->getOwner()->ParentID
                 || $original->URLSegment !== $this->getOwner()->URLSegment
             )
         ) {


### PR DESCRIPTION
## SiteTree re-organization fix

The condition did not properly match sometimes due to the type comparison which ended up causing unwanted purge static cache jobs.

Workaround for https://github.com/silverstripe/silverstripe-versioned/issues/360

Split off from https://github.com/silverstripe/silverstripe-staticpublishqueue/pull/132