### PR TITLE
PHP8 support. PHPUnit 9. Update Travis. Update test config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,57 +1,25 @@
-language: php
+version: ~> 1.0
 
-dist: xenial
+import:
+  - silverstripe/silverstripe-travis-shared:config/provision/standard.yml
 
-services:
-  - mysql
-  - postgresql
-
-cache:
-  directories:
-    - $HOME/.composer/cache/files
-
-addons:
-  apt:
-    packages:
-      - tidy
-
-matrix:
+jobs:
   fast_finish: true
   include:
-    - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=4.6.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
-    - php: 7.2
-      env: DB=PGSQL RECIPE_VERSION=4.6.x-dev PHPUNIT_TEST=1
-    - php: 7.3
-      env: DB=MYSQL RECIPE_VERSION=4.6.x-dev PDO=1 PHPUNIT_TEST=1
     - php: 7.4
-      env: DB=MYSQL RECIPE_VERSION=4.6.x-dev PHPUNIT_TEST=1
-      addons:
-        apt:
-          packages:
-            - libonig-dev
-
-before_script:
-  # Extra $PATH
-  - export PATH=~/.composer/vendor/bin:$PATH
-
-  # Init PHP
-  - phpenv rehash
-  - phpenv config-rm xdebug.ini
-  - export PATH=~/.composer/vendor/bin:$PATH
-  - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-
-  # Install composer dependencies
-  - composer validate
-  - composer require --no-update silverstripe/recipe-cms:$RECIPE_VERSION silverstripe/recipe-testing:^1
-  # Fix for running phpunit 5 on php 7.4+
-  - composer require --no-update sminnee/phpunit-mock-objects:^3
-  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:^2; fi
-  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
-
-script:
-  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests/php/ flush=1; fi
-  - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
-
-after_success:
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="4.10.x@dev"
+        - PHPCS_TEST=1
+        - PHPUNIT_TEST=1
+        - PHPUNIT_COVERAGE_TEST=1
+    - php: 8.0
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="4.10.x@dev"
+        - PHPUNIT_TEST=1
+    - php: 8.1
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="4.10.x@dev"
+        - PHPUNIT_TEST=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,25 @@
-language: php
+version: ~> 1.0
 
-dist: xenial
+import:
+  - silverstripe/silverstripe-travis-shared:config/provision/standard.yml
 
-services:
-  - mysql
-  - postgresql
-
-cache:
-  directories:
-    - $HOME/.composer/cache/files
-
-addons:
-  apt:
-    packages:
-      - tidy
-
-matrix:
+jobs:
   fast_finish: true
   include:
     - php: 7.4
-      env: DB=MYSQL RECIPE_VERSION=4.10.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="4.10.x@dev"
+        - PHPCS_TEST=1
+        - PHPUNIT_TEST=1
+        - PHPUNIT_COVERAGE_TEST=1
     - php: 8.0
-      env: DB=MYSQL RECIPE_VERSION=4.10.x-dev PHPUNIT_TEST=1
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="4.10.x@dev"
+        - PHPUNIT_TEST=1
     - php: 8.1
-      env: DB=MYSQL RECIPE_VERSION=4.10.x-dev PHPUNIT_TEST=1
-      addons:
-        apt:
-          packages:
-            - libonig-dev
-
-before_script:
-  # Extra $PATH
-  - export PATH=~/.composer/vendor/bin:$PATH
-
-  # Init PHP
-  - phpenv rehash
-  - phpenv config-rm xdebug.ini
-  - export PATH=~/.composer/vendor/bin:$PATH
-  - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-
-  # Install composer dependencies
-  - composer validate
-  - composer require --no-update silverstripe/recipe-cms:$RECIPE_VERSION
-  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:^2; fi
-  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
-
-script:
-  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests/php/ flush=1; fi
-  - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
-
-after_success:
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="4.10.x@dev"
+        - PHPUNIT_TEST=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,9 @@
 version: ~> 1.0
 
-import:
-  - silverstripe/silverstripe-travis-shared:config/provision/standard.yml
+env:
+  global:
+    - COMPOSER_ROOT_VERSION="4.x-dev"
+    - REQUIRE_RECIPE="4.x-dev"
 
-jobs:
-  fast_finish: true
-  include:
-    - php: 7.4
-      env:
-        - DB=MYSQL
-        - REQUIRE_INSTALLER="4.10.x@dev"
-        - PHPCS_TEST=1
-        - PHPUNIT_TEST=1
-        - PHPUNIT_COVERAGE_TEST=1
-    - php: 8.0
-      env:
-        - DB=MYSQL
-        - REQUIRE_INSTALLER="4.10.x@dev"
-        - PHPUNIT_TEST=1
-    - php: 8.1
-      env:
-        - DB=MYSQL
-        - REQUIRE_INSTALLER="4.10.x@dev"
-        - PHPUNIT_TEST=1
+import:
+  - silverstripe/silverstripe-travis-shared:config/provision/standard-jobs-fixed.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,53 @@
-version: ~> 1.0
+language: php
 
-import:
-  - silverstripe/silverstripe-travis-shared:config/provision/standard.yml
+dist: xenial
 
-jobs:
+services:
+  - mysql
+  - postgresql
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+addons:
+  apt:
+    packages:
+      - tidy
+
+matrix:
   fast_finish: true
   include:
     - php: 7.4
-      env:
-        - DB=MYSQL
-        - REQUIRE_INSTALLER="4.10.x@dev"
-        - PHPCS_TEST=1
-        - PHPUNIT_TEST=1
-        - PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.10.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
     - php: 8.0
-      env:
-        - DB=MYSQL
-        - REQUIRE_INSTALLER="4.10.x@dev"
-        - PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.10.x-dev PHPUNIT_TEST=1
     - php: 8.1
-      env:
-        - DB=MYSQL
-        - REQUIRE_INSTALLER="4.10.x@dev"
-        - PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.10.x-dev PHPUNIT_TEST=1
+      addons:
+        apt:
+          packages:
+            - libonig-dev
+
+before_script:
+  # Extra $PATH
+  - export PATH=~/.composer/vendor/bin:$PATH
+
+  # Init PHP
+  - phpenv rehash
+  - phpenv config-rm xdebug.ini
+  - export PATH=~/.composer/vendor/bin:$PATH
+  - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+  # Install composer dependencies
+  - composer validate
+  - composer require --no-update silverstripe/recipe-cms:$RECIPE_VERSION
+  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:^2; fi
+  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+
+script:
+  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests/php/ flush=1; fi
+  - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
+
+after_success:
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/_config/staticpublishqueue.yml
+++ b/_config/staticpublishqueue.yml
@@ -4,13 +4,21 @@ Name: staticpublishqueue
 SilverStripe\Core\Injector\Injector:
   SilverStripe\StaticPublishQueue\Publisher:
     class: SilverStripe\StaticPublishQueue\Publisher\FilesystemPublisher
-  SilverStripe\Dev\State\SapphireTestState:
-    properties:
-      States:
-        staticPublisherState: '%$SilverStripe\StaticPublishQueue\Dev\StaticPublisherState'
   SilverStripe\StaticPublishQueue\Service\UrlBundleInterface:
     class: SilverStripe\StaticPublishQueue\Service\UrlBundleService
 SilverStripe\CMS\Model\SiteTree:
   extensions:
     - SilverStripe\StaticPublishQueue\Extension\Engine\SiteTreePublishingEngine
     - SilverStripe\StaticPublishQueue\Extension\Publishable\PublishableSiteTree
+---
+Name: staticpublishqueue-tests
+Only:
+  classexists:
+    - 'Symbiote\QueuedJobs\Tests\QueuedJobsTest\QueuedJobsTest_Handler'
+    - 'SilverStripe\StaticPublishQueue\Test\QueuedJobsTestService'
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Dev\State\SapphireTestState:
+    properties:
+      States:
+        staticPublisherState: '%$SilverStripe\StaticPublishQueue\Dev\StaticPublisherState'

--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,12 @@
         "lint-clean": "phpcbf src/ tests/php/"
     },
     "prefer-stable": true,
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/recipe-plugin": true,
+            "silverstripe/vendor-plugin": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "silverstripe/versioned": "^1.6"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^1 || ^2"
+        "silverstripe/recipe-testing": "^2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         "silverstripe/versioned": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3"
+        "silverstripe/recipe-testing": "^1 || ^2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "publishing"
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.4 || ^8.0",
         "silverstripe/framework": "^4.6",
         "silverstripe/cms": "^4",
         "silverstripe/config": "^1",
@@ -26,7 +26,7 @@
         "silverstripe/versioned": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3"
     },
     "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,32 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="SilverStripe">
-	<description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
 
-	<file>src</file>
-	<file>tests</file>
+    <file>src</file>
+    <file>tests</file>
 
-	<!-- base rules are PSR-2 -->
-	<rule ref="PSR2" >
-		<!-- Current exclusions -->
-		<exclude name="PSR1.Methods.CamelCapsMethodName" />
-		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
-		<exclude name="PSR2.Classes.PropertyDeclaration" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
-		<exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
-		<exclude name="Squiz.Scope.MethodScope" />
-		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
-		<exclude name="Generic.Files.LineLength.TooLong" />
-		<exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
-	</rule>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 
-	<!-- use short array syntax -->
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />
-
-	<!-- PHP-PEG generated file not intended for human consumption -->
-	<exclude-pattern>*/SSTemplateParser.php$</exclude-pattern>
-    <exclude-pattern>*/_fakewebroot/*</exclude-pattern>
-    <exclude-pattern>*/fixtures/*</exclude-pattern>
+    <!-- base rules are PSR-2 -->
+    <rule ref="PSR2" >
+        <!-- Current exclusions -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName" />
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+        <exclude name="PSR2.Classes.PropertyDeclaration" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
+        <exclude name="Squiz.Scope.MethodScope" />
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+        <exclude name="Generic.Files.LineLength.TooLong" />
+        <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
+    </rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,22 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="SilverStripe">
-    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+	<description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
 
-    <rule ref="PSR2" >
-        <!-- Current exclusions -->
-        <exclude name="PSR1.Methods.CamelCapsMethodName" />
-        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
-    </rule>
-    <rule ref="Squiz.Strings.ConcatenationSpacing">
-        <properties>
-            <property name="spacing" value="1" />
-        </properties>
-    </rule>
-    <rule ref="Generic.Formatting.SpaceAfterNot">
-      <properties>
-            <property name="spacing" value="0" />
-        </properties>
-    </rule>
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
-    <rule ref="Squiz.Arrays.ArrayDeclaration.NoComma" />
+	<file>src</file>
+	<file>tests</file>
+
+	<!-- base rules are PSR-2 -->
+	<rule ref="PSR2" >
+		<!-- Current exclusions -->
+		<exclude name="PSR1.Methods.CamelCapsMethodName" />
+		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+		<exclude name="PSR2.Classes.PropertyDeclaration" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
+		<exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
+		<exclude name="Squiz.Scope.MethodScope" />
+		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+		<exclude name="Generic.Files.LineLength.TooLong" />
+		<exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
+	</rule>
+
+	<!-- use short array syntax -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+
+	<!-- PHP-PEG generated file not intended for human consumption -->
+	<exclude-pattern>*/SSTemplateParser.php$</exclude-pattern>
+    <exclude-pattern>*/_fakewebroot/*</exclude-pattern>
+    <exclude-pattern>*/fixtures/*</exclude-pattern>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,9 @@
             <directory suffix=".php">tests/</directory>
         </exclude>
     </coverage>
-    <testsuite name="Default">
-        <directory>tests/</directory>
-    </testsuite>
+    <testsuites>
+        <testsuite name="Default">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,15 @@
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/cms/tests/bootstrap.php"
+         colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage includeUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">tests/</directory>
+        </exclude>
+    </coverage>
     <testsuite name="Default">
         <directory>tests/</directory>
     </testsuite>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/tests/php/PublishableSiteTreeTest.php
+++ b/tests/php/PublishableSiteTreeTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\StaticPublishQueue\Test;
 
+use PHPUnit\Framework\MockObject\Stub\ReturnCallback;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
@@ -24,7 +25,7 @@ class PublishableSiteTreeTest extends SapphireTest
         PublishablePage::class,
     ];
 
-    public function testObjectsToUpdateOnURLSegmentChange()
+    public function testObjectsToUpdateOnURLSegmentChange(): void
     {
         $this->setExpectedFlushChangesOutput([
             [[], ['stub/']],
@@ -45,7 +46,7 @@ class PublishableSiteTreeTest extends SapphireTest
         $page->publishRecursive();
     }
 
-    public function testObjectsToUpdateOnURLSegmentChangeWithParents()
+    public function testObjectsToUpdateOnURLSegmentChangeWithParents(): void
     {
         $this->setExpectedFlushChangesOutput([
             [[], ['parent/']],
@@ -73,7 +74,7 @@ class PublishableSiteTreeTest extends SapphireTest
         $page->publishRecursive();
     }
 
-    public function testObjectsToUpdateOnSiteTreeRearrange()
+    public function testObjectsToUpdateOnSiteTreeRearrange(): void
     {
         $this->setExpectedFlushChangesOutput([
             [[], ['parent/']],
@@ -110,7 +111,7 @@ class PublishableSiteTreeTest extends SapphireTest
         $page->publishRecursive();
     }
 
-    public function testObjectsToUpdateOnPublish()
+    public function testObjectsToUpdateOnPublish(): void
     {
         $parent = new PublishablePage;
 
@@ -136,7 +137,7 @@ class PublishableSiteTreeTest extends SapphireTest
         $this->assertCount(2, $objects);
     }
 
-    public function testObjectsToUpdateOnUnpublish()
+    public function testObjectsToUpdateOnUnpublish(): void
     {
         $parent = new PublishablePage;
 
@@ -166,14 +167,14 @@ class PublishableSiteTreeTest extends SapphireTest
         $this->assertCount(1, $updates);
     }
 
-    public function testObjectsToDeleteOnPublish()
+    public function testObjectsToDeleteOnPublish(): void
     {
         $stub = new PublishablePage;
         $objects = $stub->objectsToDelete(['action' => 'publish']);
         $this->assertEmpty($objects);
     }
 
-    public function testObjectsToDeleteOnUnpublish()
+    public function testObjectsToDeleteOnUnpublish(): void
     {
         $stub = new PublishablePage;
         $stub->Title = 'stub';
@@ -182,7 +183,7 @@ class PublishableSiteTreeTest extends SapphireTest
         $this->assertCount(1, $objects);
     }
 
-    public function testObjectsToUpdateOnPublishIfVirtualExists()
+    public function testObjectsToUpdateOnPublishIfVirtualExists(): void
     {
         $redir = new PublishablePage;
 
@@ -204,7 +205,7 @@ class PublishableSiteTreeTest extends SapphireTest
         $this->assertCount(2, $objects);
     }
 
-    public function testObjectsToDeleteOnUnpublishIfVirtualExists()
+    public function testObjectsToDeleteOnUnpublishIfVirtualExists(): void
     {
         $redir = new PublishablePage;
 
@@ -271,7 +272,7 @@ class PublishableSiteTreeTest extends SapphireTest
         foreach ($map as $urls) {
             ++$count;
             list($toDelete, $toUpdate) = $urls;
-            $callbacks[] = new \PHPUnit_Framework_MockObject_Stub_ReturnCallback(
+            $callbacks[] = new ReturnCallback(
                 function () use ($toDelete, $toUpdate, $mockExtension, $getURL, $count) {
                     $this->assertSame(
                         $toDelete,

--- a/tests/php/Publisher/FilesystemPublisherTest.php
+++ b/tests/php/Publisher/FilesystemPublisherTest.php
@@ -156,6 +156,14 @@ class FilesystemPublisherTest extends SapphireTest
         $level2_1->write();
         $level2_1->publishRecursive();
 
+        $level2_2 = new StaticPublisherTestPage();
+        $level2_2->URLSegment = 'test-level-2-2';
+        $level2_2->ParentID = $level1->ID;
+        $level2_2->write();
+        $level2_2->publishRecursive();
+
+        $this->logOut();
+
         $this->fsp->publishURL($level1->Link(), true);
         $this->fsp->publishURL($level2_1->Link(), true);
         $static2_1FilePath = $this->fsp->getDestPath() . $urlToPath->invokeArgs($this->fsp, [$level2_1->Link()]);
@@ -166,12 +174,6 @@ class FilesystemPublisherTest extends SapphireTest
             'current',
             file_get_contents($static2_1FilePath . '.html')
         );
-
-        $level2_2 = new StaticPublisherTestPage();
-        $level2_2->URLSegment = 'test-level-2-2';
-        $level2_2->ParentID = $level1->ID;
-        $level2_2->write();
-        $level2_2->publishRecursive();
 
         $this->fsp->publishURL($level2_2->Link(), true);
         $static2_2FilePath = $this->fsp->getDestPath() . $urlToPath->invokeArgs($this->fsp, [$level2_2->Link()]);
@@ -193,6 +195,8 @@ class FilesystemPublisherTest extends SapphireTest
         $level1->write();
         $level1->publishRecursive();
 
+        $this->logOut();
+
         $this->fsp->publishURL($level1->Link(), true);
         $staticFilePath = $this->fsp->getDestPath() . 'mimetype';
 
@@ -211,6 +215,8 @@ class FilesystemPublisherTest extends SapphireTest
         $level1->write();
         $level1->publishRecursive();
 
+        $this->logOut();
+
         $this->fsp->publishURL('to-be-purged', true);
         $this->assertFileExists($this->fsp->getDestPath() . 'to-be-purged.html');
         $this->assertFileExists($this->fsp->getDestPath() . 'to-be-purged.php');
@@ -227,6 +233,8 @@ class FilesystemPublisherTest extends SapphireTest
         $level1->write();
         $level1->publishRecursive();
 
+        $this->logOut();
+
         $this->fsp->publishURL('purge-me', true);
         $this->assertFileExists($this->fsp->getDestPath() . 'purge-me.html');
         $this->assertFileExists($this->fsp->getDestPath() . 'purge-me.php');
@@ -240,6 +248,8 @@ class FilesystemPublisherTest extends SapphireTest
 
     public function testNoErrorPagesWhenHTMLOnly(): void
     {
+        $this->logOut();
+
         $this->fsp->setFileExtension('html');
 
         $this->fsp->publishURL('not_really_there', true);
@@ -249,6 +259,8 @@ class FilesystemPublisherTest extends SapphireTest
 
     public function testErrorPageWhenPHP(): void
     {
+        $this->logOut();
+
         $this->fsp->publishURL('not_really_there', true);
         $this->assertFileExists($this->fsp->getDestPath() . 'not_really_there.html');
         $this->assertFileExists($this->fsp->getDestPath() . 'not_really_there.php');
@@ -264,6 +276,8 @@ class FilesystemPublisherTest extends SapphireTest
         $redirectorPage->ExternalURL = 'silverstripe.org';
         $redirectorPage->write();
         $redirectorPage->publishRecursive();
+
+        $this->logOut();
 
         $this->fsp->publishURL('somewhere-else', true);
 
@@ -288,6 +302,8 @@ class FilesystemPublisherTest extends SapphireTest
         $redirectorPage->ExternalURL = 'silverstripe.org';
         $redirectorPage->write();
         $redirectorPage->publishRecursive();
+
+        $this->logOut();
 
         $this->fsp->publishURL('somewhere-else', true);
 
@@ -331,17 +347,19 @@ class FilesystemPublisherTest extends SapphireTest
         $level1->write();
         $level1->publishRecursive();
 
-        $this->fsp->publishURL('find-me', true);
-        // We have to redeclare this config because the testkernel wipes it when we generate the page response
-        Director::config()->set('alternate_base_url', 'http://example.com');
-
-        $this->assertSame(['http://example.com/find-me'], $this->fsp->getPublishedURLs());
-
         $level2_1 = new StaticPublisherTestPage();
         $level2_1->URLSegment = 'find-me-child';
         $level2_1->ParentID = $level1->ID;
         $level2_1->write();
         $level2_1->publishRecursive();
+
+        $this->logOut();
+
+        $this->fsp->publishURL('find-me', true);
+        // We have to redeclare this config because the testkernel wipes it when we generate the page response
+        Director::config()->set('alternate_base_url', 'http://example.com');
+
+        $this->assertSame(['http://example.com/find-me'], $this->fsp->getPublishedURLs());
 
         $this->fsp->publishURL($level2_1->Link(), true);
         Director::config()->set('alternate_base_url', 'http://example.com');

--- a/tests/php/Publisher/FilesystemPublisherTest.php
+++ b/tests/php/Publisher/FilesystemPublisherTest.php
@@ -67,17 +67,17 @@ class FilesystemPublisherTest extends SapphireTest
         $urlToPath = $reflection->getMethod('URLtoPath');
         $urlToPath->setAccessible(true);
 
-        $this->assertSame(
+        $this->assertEquals(
             'index',
             $urlToPath->invokeArgs($this->fsp, ['/'])
         );
 
-        $this->assertSame(
+        $this->assertEquals(
             'about-us',
             $urlToPath->invokeArgs($this->fsp, ['about-us'])
         );
 
-        $this->assertSame(
+        $this->assertEquals(
             'parent/child',
             $urlToPath->invokeArgs($this->fsp, ['parent/child'])
         );
@@ -90,19 +90,19 @@ class FilesystemPublisherTest extends SapphireTest
         $urlToPath->setAccessible(true);
 
         $url = Director::absoluteBaseUrl();
-        $this->assertSame(
+        $this->assertEquals(
             'index',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
 
         $url = Director::absoluteBaseUrl() . 'about-us';
-        $this->assertSame(
+        $this->assertEquals(
             'about-us',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
 
         $url = Director::absoluteBaseUrl() . 'parent/child';
-        $this->assertSame(
+        $this->assertEquals(
             'parent/child',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
@@ -119,19 +119,19 @@ class FilesystemPublisherTest extends SapphireTest
         $this->fsp->setFileExtension('html');
 
         $url = 'http://domain1.com/';
-        $this->assertSame(
+        $this->assertEquals(
             'domain1.com/index',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
 
         $url = 'http://domain1.com/about-us';
-        $this->assertSame(
+        $this->assertEquals(
             'domain1.com/about-us',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
 
         $url = 'http://domain2.com/parent/child';
-        $this->assertSame(
+        $this->assertEquals(
             'domain2.com/parent/child',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
@@ -170,7 +170,7 @@ class FilesystemPublisherTest extends SapphireTest
 
         $this->assertFileExists($static2_1FilePath . '.html');
         $this->assertFileExists($static2_1FilePath . '.php');
-        $this->assertContains(
+        $this->assertStringContainsString(
             'current',
             file_get_contents($static2_1FilePath . '.html')
         );
@@ -180,7 +180,7 @@ class FilesystemPublisherTest extends SapphireTest
 
         $this->assertFileExists($static2_2FilePath . '.html');
         $this->assertFileExists($static2_2FilePath . '.php');
-        $this->assertContains(
+        $this->assertStringContainsString(
             'linkcurrent',
             file_get_contents($static2_2FilePath . '.html')
         );
@@ -202,7 +202,7 @@ class FilesystemPublisherTest extends SapphireTest
 
         $this->assertFileExists($staticFilePath . '.html');
         $this->assertFileDoesNotExist($staticFilePath . '.php');
-        $this->assertSame(
+        $this->assertEquals(
             '<div class="statically-published" style="display: none"></div>',
             trim(file_get_contents($staticFilePath . '.html'))
         );
@@ -265,7 +265,7 @@ class FilesystemPublisherTest extends SapphireTest
         $this->assertFileExists($this->fsp->getDestPath() . 'not_really_there.html');
         $this->assertFileExists($this->fsp->getDestPath() . 'not_really_there.php');
         $phpCacheConfig = require $this->fsp->getDestPath() . 'not_really_there.php';
-        $this->assertSame(404, $phpCacheConfig['responseCode']);
+        $this->assertEquals(404, $phpCacheConfig['responseCode']);
     }
 
     public function testRedirectorPageWhenPHP(): void
@@ -282,13 +282,13 @@ class FilesystemPublisherTest extends SapphireTest
         $this->fsp->publishURL('somewhere-else', true);
 
         $this->assertFileExists($this->fsp->getDestPath() . 'somewhere-else.html');
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Click this link if your browser does not redirect you',
             file_get_contents($this->fsp->getDestPath() . 'somewhere-else.html')
         );
         $this->assertFileExists($this->fsp->getDestPath() . 'somewhere-else.php');
         $phpCacheConfig = require $this->fsp->getDestPath() . 'somewhere-else.php';
-        $this->assertSame(301, $phpCacheConfig['responseCode']);
+        $this->assertEquals(301, $phpCacheConfig['responseCode']);
         $this->assertContains('location: http://silverstripe.org', $phpCacheConfig['headers']);
     }
 
@@ -308,7 +308,7 @@ class FilesystemPublisherTest extends SapphireTest
         $this->fsp->publishURL('somewhere-else', true);
 
         $this->assertFileExists($this->fsp->getDestPath() . 'somewhere-else.html');
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Click this link if your browser does not redirect you',
             file_get_contents($this->fsp->getDestPath() . 'somewhere-else.html')
         );
@@ -324,7 +324,7 @@ class FilesystemPublisherTest extends SapphireTest
         $pathToURL = $reflection->getMethod('pathToURL');
         $pathToURL->setAccessible(true);
 
-        $this->assertSame(
+        $this->assertEquals(
             $expected,
             $pathToURL->invoke($this->fsp, $this->fsp->getDestPath() . $path)
         );
@@ -359,7 +359,7 @@ class FilesystemPublisherTest extends SapphireTest
         // We have to redeclare this config because the testkernel wipes it when we generate the page response
         Director::config()->set('alternate_base_url', 'http://example.com');
 
-        $this->assertSame(['http://example.com/find-me'], $this->fsp->getPublishedURLs());
+        $this->assertEquals(['http://example.com/find-me'], $this->fsp->getPublishedURLs());
 
         $this->fsp->publishURL($level2_1->Link(), true);
         Director::config()->set('alternate_base_url', 'http://example.com');
@@ -370,6 +370,6 @@ class FilesystemPublisherTest extends SapphireTest
         $this->assertCount(2, $urls);
 
         $this->fsp->purgeURL('find-me');
-        $this->assertSame(['http://example.com/find-me/find-me-child'], $this->fsp->getPublishedURLs());
+        $this->assertEquals(['http://example.com/find-me/find-me-child'], $this->fsp->getPublishedURLs());
     }
 }

--- a/tests/php/Publisher/FilesystemPublisherTest.php
+++ b/tests/php/Publisher/FilesystemPublisherTest.php
@@ -67,17 +67,17 @@ class FilesystemPublisherTest extends SapphireTest
         $urlToPath = $reflection->getMethod('URLtoPath');
         $urlToPath->setAccessible(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'index',
             $urlToPath->invokeArgs($this->fsp, ['/'])
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'about-us',
             $urlToPath->invokeArgs($this->fsp, ['about-us'])
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'parent/child',
             $urlToPath->invokeArgs($this->fsp, ['parent/child'])
         );
@@ -90,19 +90,19 @@ class FilesystemPublisherTest extends SapphireTest
         $urlToPath->setAccessible(true);
 
         $url = Director::absoluteBaseUrl();
-        $this->assertEquals(
+        $this->assertSame(
             'index',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
 
         $url = Director::absoluteBaseUrl() . 'about-us';
-        $this->assertEquals(
+        $this->assertSame(
             'about-us',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
 
         $url = Director::absoluteBaseUrl() . 'parent/child';
-        $this->assertEquals(
+        $this->assertSame(
             'parent/child',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
@@ -119,19 +119,19 @@ class FilesystemPublisherTest extends SapphireTest
         $this->fsp->setFileExtension('html');
 
         $url = 'http://domain1.com/';
-        $this->assertEquals(
+        $this->assertSame(
             'domain1.com/index',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
 
         $url = 'http://domain1.com/about-us';
-        $this->assertEquals(
+        $this->assertSame(
             'domain1.com/about-us',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
 
         $url = 'http://domain2.com/parent/child';
-        $this->assertEquals(
+        $this->assertSame(
             'domain2.com/parent/child',
             $urlToPath->invokeArgs($this->fsp, [$url])
         );
@@ -202,7 +202,7 @@ class FilesystemPublisherTest extends SapphireTest
 
         $this->assertFileExists($staticFilePath . '.html');
         $this->assertFileDoesNotExist($staticFilePath . '.php');
-        $this->assertEquals(
+        $this->assertSame(
             '<div class="statically-published" style="display: none"></div>',
             trim(file_get_contents($staticFilePath . '.html'))
         );
@@ -265,7 +265,7 @@ class FilesystemPublisherTest extends SapphireTest
         $this->assertFileExists($this->fsp->getDestPath() . 'not_really_there.html');
         $this->assertFileExists($this->fsp->getDestPath() . 'not_really_there.php');
         $phpCacheConfig = require $this->fsp->getDestPath() . 'not_really_there.php';
-        $this->assertEquals(404, $phpCacheConfig['responseCode']);
+        $this->assertSame(404, $phpCacheConfig['responseCode']);
     }
 
     public function testRedirectorPageWhenPHP(): void
@@ -288,7 +288,7 @@ class FilesystemPublisherTest extends SapphireTest
         );
         $this->assertFileExists($this->fsp->getDestPath() . 'somewhere-else.php');
         $phpCacheConfig = require $this->fsp->getDestPath() . 'somewhere-else.php';
-        $this->assertEquals(301, $phpCacheConfig['responseCode']);
+        $this->assertSame(301, $phpCacheConfig['responseCode']);
         $this->assertContains('location: http://silverstripe.org', $phpCacheConfig['headers']);
     }
 
@@ -324,7 +324,7 @@ class FilesystemPublisherTest extends SapphireTest
         $pathToURL = $reflection->getMethod('pathToURL');
         $pathToURL->setAccessible(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $pathToURL->invoke($this->fsp, $this->fsp->getDestPath() . $path)
         );
@@ -359,7 +359,7 @@ class FilesystemPublisherTest extends SapphireTest
         // We have to redeclare this config because the testkernel wipes it when we generate the page response
         Director::config()->set('alternate_base_url', 'http://example.com');
 
-        $this->assertEquals(['http://example.com/find-me'], $this->fsp->getPublishedURLs());
+        $this->assertSame(['http://example.com/find-me'], $this->fsp->getPublishedURLs());
 
         $this->fsp->publishURL($level2_1->Link(), true);
         Director::config()->set('alternate_base_url', 'http://example.com');
@@ -370,6 +370,6 @@ class FilesystemPublisherTest extends SapphireTest
         $this->assertCount(2, $urls);
 
         $this->fsp->purgeURL('find-me');
-        $this->assertEquals(['http://example.com/find-me/find-me-child'], $this->fsp->getPublishedURLs());
+        $this->assertSame(['http://example.com/find-me/find-me-child'], $this->fsp->getPublishedURLs());
     }
 }

--- a/tests/php/Publisher/FilesystemPublisherTest.php
+++ b/tests/php/Publisher/FilesystemPublisherTest.php
@@ -35,7 +35,7 @@ class FilesystemPublisherTest extends SapphireTest
         ],
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class FilesystemPublisherTest extends SapphireTest
         $this->fsp = $mockFSP->setDestFolder('cache/testing/');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->fsp !== null && file_exists($this->fsp->getDestPath())) {
             Filesystem::removeFolder($this->fsp->getDestPath());
@@ -61,7 +61,7 @@ class FilesystemPublisherTest extends SapphireTest
         parent::tearDown();
     }
 
-    public function testUrlToPathWithRelativeUrls()
+    public function testUrlToPathWithRelativeUrls(): void
     {
         $reflection = new \ReflectionClass(FilesystemPublisher::class);
         $urlToPath = $reflection->getMethod('URLtoPath');
@@ -83,7 +83,7 @@ class FilesystemPublisherTest extends SapphireTest
         );
     }
 
-    public function testUrlToPathWithAbsoluteUrls()
+    public function testUrlToPathWithAbsoluteUrls(): void
     {
         $reflection = new \ReflectionClass(FilesystemPublisher::class);
         $urlToPath = $reflection->getMethod('URLtoPath');
@@ -108,7 +108,7 @@ class FilesystemPublisherTest extends SapphireTest
         );
     }
 
-    public function testUrlToPathWithDomainBasedCaching()
+    public function testUrlToPathWithDomainBasedCaching(): void
     {
         Config::modify()->set(FilesystemPublisher::class, 'domain_based_caching', true);
 
@@ -137,7 +137,7 @@ class FilesystemPublisherTest extends SapphireTest
         );
     }
 
-    public function testMenu2LinkingMode()
+    public function testMenu2LinkingMode(): void
     {
         SSViewer::set_themes(null);
 
@@ -184,7 +184,7 @@ class FilesystemPublisherTest extends SapphireTest
         );
     }
 
-    public function testOnlyHTML()
+    public function testOnlyHTML(): void
     {
         $this->fsp->setFileExtension('html');
 
@@ -197,14 +197,14 @@ class FilesystemPublisherTest extends SapphireTest
         $staticFilePath = $this->fsp->getDestPath() . 'mimetype';
 
         $this->assertFileExists($staticFilePath . '.html');
-        $this->assertFileNotExists($staticFilePath . '.php');
+        $this->assertFileDoesNotExist($staticFilePath . '.php');
         $this->assertSame(
             '<div class="statically-published" style="display: none"></div>',
             trim(file_get_contents($staticFilePath . '.html'))
         );
     }
 
-    public function testPurgeURL()
+    public function testPurgeURL(): void
     {
         $level1 = new StaticPublisherTestPage();
         $level1->URLSegment = 'to-be-purged';
@@ -216,11 +216,11 @@ class FilesystemPublisherTest extends SapphireTest
         $this->assertFileExists($this->fsp->getDestPath() . 'to-be-purged.php');
 
         $this->fsp->purgeURL('to-be-purged');
-        $this->assertFileNotExists($this->fsp->getDestPath() . 'to-be-purged.html');
-        $this->assertFileNotExists($this->fsp->getDestPath() . 'to-be-purged.php');
+        $this->assertFileDoesNotExist($this->fsp->getDestPath() . 'to-be-purged.html');
+        $this->assertFileDoesNotExist($this->fsp->getDestPath() . 'to-be-purged.php');
     }
 
-    public function testPurgeURLAfterSwitchingExtensions()
+    public function testPurgeURLAfterSwitchingExtensions(): void
     {
         $level1 = new StaticPublisherTestPage();
         $level1->URLSegment = 'purge-me';
@@ -234,20 +234,20 @@ class FilesystemPublisherTest extends SapphireTest
         $this->fsp->setFileExtension('html');
 
         $this->fsp->purgeURL('purge-me');
-        $this->assertFileNotExists($this->fsp->getDestPath() . 'purge-me.html');
-        $this->assertFileNotExists($this->fsp->getDestPath() . 'purge-me.php');
+        $this->assertFileDoesNotExist($this->fsp->getDestPath() . 'purge-me.html');
+        $this->assertFileDoesNotExist($this->fsp->getDestPath() . 'purge-me.php');
     }
 
-    public function testNoErrorPagesWhenHTMLOnly()
+    public function testNoErrorPagesWhenHTMLOnly(): void
     {
         $this->fsp->setFileExtension('html');
 
         $this->fsp->publishURL('not_really_there', true);
-        $this->assertFileNotExists($this->fsp->getDestPath() . 'not_really_there.html');
-        $this->assertFileNotExists($this->fsp->getDestPath() . 'not_really_there.php');
+        $this->assertFileDoesNotExist($this->fsp->getDestPath() . 'not_really_there.html');
+        $this->assertFileDoesNotExist($this->fsp->getDestPath() . 'not_really_there.php');
     }
 
-    public function testErrorPageWhenPHP()
+    public function testErrorPageWhenPHP(): void
     {
         $this->fsp->publishURL('not_really_there', true);
         $this->assertFileExists($this->fsp->getDestPath() . 'not_really_there.html');
@@ -256,7 +256,7 @@ class FilesystemPublisherTest extends SapphireTest
         $this->assertSame(404, $phpCacheConfig['responseCode']);
     }
 
-    public function testRedirectorPageWhenPHP()
+    public function testRedirectorPageWhenPHP(): void
     {
         $redirectorPage = RedirectorPage::create();
         $redirectorPage->URLSegment = 'somewhere-else';
@@ -278,7 +278,7 @@ class FilesystemPublisherTest extends SapphireTest
         $this->assertContains('location: http://silverstripe.org', $phpCacheConfig['headers']);
     }
 
-    public function testRedirectorPageWhenHTMLOnly()
+    public function testRedirectorPageWhenHTMLOnly(): void
     {
         $this->fsp->setFileExtension('html');
 
@@ -296,13 +296,13 @@ class FilesystemPublisherTest extends SapphireTest
             'Click this link if your browser does not redirect you',
             file_get_contents($this->fsp->getDestPath() . 'somewhere-else.html')
         );
-        $this->assertFileNotExists($this->fsp->getDestPath() . 'somewhere-else.php');
+        $this->assertFileDoesNotExist($this->fsp->getDestPath() . 'somewhere-else.php');
     }
 
     /**
      * @dataProvider providePathsToURL
      */
-    public function testPathToURL($expected, $path)
+    public function testPathToURL($expected, $path): void
     {
         $reflection = new \ReflectionClass(FilesystemPublisher::class);
         $pathToURL = $reflection->getMethod('pathToURL');
@@ -324,7 +324,7 @@ class FilesystemPublisherTest extends SapphireTest
         ];
     }
 
-    public function testGetPublishedURLs()
+    public function testGetPublishedURLs(): void
     {
         $level1 = new StaticPublisherTestPage();
         $level1->URLSegment = 'find-me';

--- a/tests/php/SiteTreePublishingEngineTest.php
+++ b/tests/php/SiteTreePublishingEngineTest.php
@@ -7,7 +7,7 @@ use SilverStripe\StaticPublishQueue\Test\SiteTreePublishingEngineTest\Model\Stat
 
 class SiteTreePublishingEngineTest extends SapphireTest
 {
-    public function testCollectChangesForPublishing()
+    public function testCollectChangesForPublishing(): void
     {
         $obj = StaticPublishingTriggerPage::create();
         $obj->collectChanges(['action' => 'publish']);
@@ -22,7 +22,7 @@ class SiteTreePublishingEngineTest extends SapphireTest
         );
     }
 
-    public function testCollectChangesForUnpublishing()
+    public function testCollectChangesForUnpublishing(): void
     {
         $obj = StaticPublishingTriggerPage::create();
         $obj->collectChanges(['action' => 'unpublish']);

--- a/tests/php/UrlBundleServiceTest.php
+++ b/tests/php/UrlBundleServiceTest.php
@@ -43,7 +43,7 @@ class UrlBundleServiceTest extends SapphireTest
         $this->assertCount(1, $messages);
 
         $messageData = array_shift($messages);
-        $this->assertContains($message, $messageData);
+        $this->assertStringContainsString($message, $messageData);
     }
 
     /**


### PR DESCRIPTION
Fixes #135
Fixes #138

## PHP Unit 9

Not too much had to update here. Just the usual missing `: void` declarations, and I needed to update some deprecated methods and `assertContains` to the new `assetStringContainsString`.

## Travis update

I'm not 100% across all of the settings that used to be there (in particular the cache dir settings). I've really just grabbed what is the latest "template" from some other Silverstripe modules. 🤞 

## Updated yml config

- [x] Manually tested that a project without `--prefer-source` can successfully run its own unit tests without these missing classes throwing an error (as described in #138)

## Practical test

- [x] Manually test that project purges URLs when unpublished
- [x] Manually test that project builds URLs when published
- [x] Manually test that project rebuilds parent URLs when child is published or unpublished