### PR TITLE
5.2: Fix order of setup() for Full Build Job

### DIFF
--- a/src/Job/StaticCacheFullBuildJob.php
+++ b/src/Job/StaticCacheFullBuildJob.php
@@ -42,11 +42,12 @@ class StaticCacheFullBuildJob extends Job
 
     public function setup(): void
     {
-        parent::setup();
-        Publisher::singleton()->purgeAll();
         $this->URLsToProcess = $this->getAllLivePageURLs();
         $this->URLsToCleanUp = [];
-        $this->totalSteps = count($this->URLsToProcess);
+
+        parent::setup();
+
+        Publisher::singleton()->purgeAll();
         $this->addMessage(sprintf('Building %s URLS', count($this->URLsToProcess)));
         $this->addMessage(var_export(array_keys($this->URLsToProcess), true));
     }


### PR DESCRIPTION
Apologies team, I should have picked this up during my PHP 8 PR testing. Turns out... the project I was testing on has it's own Job called the exact same thing, so I **thought** I was testing this, but I was testing our bespoke one /face-palm.

`parent::setup()` will trigger the following assignment:
```php
$this->totalSteps = count($this->URLsToProcess)
```

So, `$this->URLsToProcess` needs to be set before that happens.

I'm not too sure why this worked before PHP 8 (or maybe it didn't?).