### PR TITLE
BUG: Protect against URLsToProcess being falsy

### DIFF
--- a/tests/php/RunDeleteCacheJobTest.php
+++ b/tests/php/RunDeleteCacheJobTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\StaticPublishQueue\Job;
+
+use SilverStripe\Dev\FunctionalTest;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+class RunDeleteCacheJobTest extends FunctionalTest
+{
+    public function testHydrationAffectsSignature()
+    {
+        $job = new DeleteStaticCacheJob();
+        $data = $job->getJobData();
+        $signature = $job->getSignature();
+        $this->assertEmpty($data->jobData);
+        $this->assertFalse($data->isComplete);
+
+        $job->hydrate(['/' => 1], null);
+        $data = $job->getJobData();
+        $this->assertIsObject($data->jobData);
+        $this->assertFalse($data->isComplete);
+        $hydratedSignature = $job->getSignature();
+
+        // hydrating the job should affect the signature
+        $this->assertNotEquals($signature, $hydratedSignature);
+    }
+
+    // test that the job can process regardless of URLsToProcess
+    public function testJobCanComplete()
+    {
+        $job = new DeleteStaticCacheJob();
+        $job->process();
+        $data = $job->getJobData();
+        $this->assertTrue($data->isComplete);
+
+        $job = new DeleteStaticCacheJob();
+        $job->hydrate(['/' => 1], null);
+        $job->process();
+        $data = $job->getJobData();
+        $this->assertTrue($data->isComplete);
+    }
+}


### PR DESCRIPTION
If URLsToProcess is null then a error will be thrown when trying to create a Delete cache job because array_keys expects an array.

[Emergency] Uncaught TypeError: array_keys(): Argument `#1` ($array) must be of type array, null given
POST /admin/queuedjobs/Symbiote-QueuedJobs-DataObjects-QueuedJobDescriptor/EditForm
Line 107 in /var/www/stats/vendor/silverstripe/staticpublishqueue/src/Job.ph