### PR TITLE
FIX Revert change to URL segment and update docs

### DIFF
--- a/docs/en/building_the_cache.md
+++ b/docs/en/building_the_cache.md
@@ -15,7 +15,7 @@ method.
 
 You can generate cache files for the entire site via the `StaticCacheFullBuildJob`.
 This can either be queued up from the QueuedJobs interface or via the task
-`dev/tasks/StaticCacheFullBuildTask`. This task also takes a parameter `?startAfter`
+`dev/tasks/SilverStripe-StaticPublishQueue-Task-StaticCacheFullBuildTask`. This task also takes a parameter `?startAfter`
 which can delay the execution of the job. The parameter should be in HHMM format, 
 e.g. to start after 2pm, pass `?startAfter=1400`. If it's already after the proposed
 time on the current day, it will push it to the next day.
@@ -25,6 +25,6 @@ example configuration would be:
 
 ```bash
 # build the cache at 1am every day 
-0 1 * * * www-data /path/to/sake dev/tasks/StaticCacheFullBuildTask
+0 1 * * * www-data /path/to/sake dev/tasks/SilverStripe-StaticPublishQueue-Task-StaticCacheFullBuildTask
 ```
 

--- a/src/Task/StaticCacheFullBuildTask.php
+++ b/src/Task/StaticCacheFullBuildTask.php
@@ -15,8 +15,6 @@ use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 class StaticCacheFullBuildTask extends BuildTask
 {
-    private static $segment = 'StaticCacheFullBuildTask';
-    
     /**
      * Queue up a StaticCacheFullBuildJob
      * Check for startAfter param and do some sanity checking


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-staticpublishqueue/issues/144

Reverts https://github.com/silverstripe/silverstripe-staticpublishqueue/commit/2f05ec1ec3ca0837b258564dc30034676f2d67d1 which would break existing cron jobs. Also updates docs.

By the looks of things, `$segment` wasn't added when going from the CMS 3 to the CMS 4 versions of staticpublishqueue when namespaces where added, which caused the change in rendered segment from `StaticCacheFullBuildTask` to `SilverStripe-StaticPublishQueue-Task-StaticCacheFullBuildTask`

It would be preferably to have the `$segment` defined, however that would require a new major version since it is a breaking change