### PR TITLE
NEW Option to not cache RedirectorPages

### DIFF
--- a/docs/en/basic_configuration.md
+++ b/docs/en/basic_configuration.md
@@ -48,6 +48,14 @@ class MyFormPage extends Page
 }
 ```
 
+## Excluding RedirectorPages
+By default the page that a `RedirectorPage` points to will be cached if all project pages are statically publishable i.e. `Page implements StaticallyPublishable`. However, if the page the `RedirectorPage` points to was meant be be excluded via `urlsToCache()` method, then the page will still be cached which means you may accidentally cache pages you did not intend to. To prevent this from happening, use the following config:
+
+```yml
+SilverStripe\StaticPublishQueue\Publisher:
+  cache_redirector_pages: false
+```
+
 ## Available interfaces
 
 This module comes with two essential interfaces: `StaticPublishingTrigger` and `StaticallyPublishable`. This interfaces

--- a/src/Extension/Engine/SiteTreePublishingEngine.php
+++ b/src/Extension/Engine/SiteTreePublishingEngine.php
@@ -4,6 +4,7 @@ namespace SilverStripe\StaticPublishQueue\Extension\Engine;
 
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Model\SiteTreeExtension;
+use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Resettable;

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -57,6 +57,11 @@ abstract class Publisher implements StaticPublisher
     private static $add_timestamp = false;
 
     /**
+     * Cache redirector pages which will cache as the page they're redirected to
+     */
+    private static $cache_redirector_pages = true;
+
+    /**
      * @param string $url
      *
      * @return HTTPResponse


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-staticpublishqueue/issues/154

No unit tests because I'm struggling to unit test a `RedirectorPage extends Page` when `Page` doesn't exist in the module, though it does inside a project, and also the assumption is the `Page::urlsToCache()` exists, which again it may or may not depending where the unit test is run.
