### PR TITLE
MNT Remove branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,6 @@
     "include-path": [
         "includes/"
     ],
-    "extra": {
-        "branch-alias": {
-            "dev-master": "5.x-dev"
-        }
-    },
     "scripts": {
         "lint": "phpcs -s src/ tests/php/",
         "lint-clean": "phpcbf src/ tests/php/"


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/676

This is for the `master` branch