### PR TITLE
Bugfix: Use copy() and unlink() instead of rename()

### DIFF
--- a/src/Publisher/FilesystemPublisher.php
+++ b/src/Publisher/FilesystemPublisher.php
@@ -190,7 +190,14 @@ class FilesystemPublisher extends Publisher
         $publishPath = $this->getDestPath() . DIRECTORY_SEPARATOR . $filePath;
         Filesystem::makeFolder(dirname($publishPath));
 
-        return rename($temporaryPath, $publishPath);
+        // Attempt to copy this file to its permanent location
+        $copyResult = copy($temporaryPath, $publishPath);
+        // We want to unlink the temporary file regardless of copy() success, as new temporary files would be created
+        // when this action is attempted again
+        unlink($temporaryPath);
+
+        // Return copy() result
+        return $copyResult;
     }
 
     protected function deleteFromPath($filePath)


### PR DESCRIPTION
When attempting to process `GenerateStaticCacheJob`:
```
ERROR [Warning]: rename(/tmp/silverstripe-cache-php8.1.14-var-www-mysite-www/vagrant/filesystempublisher_lhg6Yg,/var/www/mysite/www/public/cache/copyright-and-legal-statement.html): Operation not permitted
IN GET dev/tasks/ProcessJobQueueTask
Line 193 in /var/www/mysite/www/vendor/silverstripe/staticpublishqueue/src/Publisher/FilesystemPublisher.php
```

My directories all have the appropriate permissions.

Found this thread, which talks about similar issues, and it sounded like `copy()` and `unlink()` had more success:
https://ubuntuforums.org/showthread.php?t=1272466

I confirmed this to be true for us. I no longer get any Warning when performing these two actions separately.

## Related resources
* [Introduction of rename()](https://github.com/silverstripe/silverstripe-staticpublishqueue/commit/fb4976867731cca3cae968b1e52e16fa874b4ddd) to the codebase