### PR TITLE
MNT Fix unit test in kitchen sink

### DIFF
--- a/tests/php/RunDeleteCacheJobTest.php
+++ b/tests/php/RunDeleteCacheJobTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\StaticPublishQueue\Job;
 
 use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\Subsites\State\SubsiteState;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 class RunDeleteCacheJobTest extends FunctionalTest
@@ -12,7 +13,14 @@ class RunDeleteCacheJobTest extends FunctionalTest
         $job = new DeleteStaticCacheJob();
         $data = $job->getJobData();
         $signature = $job->getSignature();
-        $this->assertEmpty($data->jobData);
+        if (class_exists(SubsiteState::class)) {
+            // The subsite ID is added via `AbstractQueuedJob::getJobData()`
+            // Without accounting for that, this test fails in the kitchen sink.
+            $expected = ['SubsiteID' => SubsiteState::singleton()->getSubsiteId()];
+            $this->assertSame($expected, json_decode(json_encode($data->jobData), true));
+        } else {
+            $this->assertEmpty($data->jobData);
+        }
         $this->assertFalse($data->isComplete);
 
         $job->hydrate(['/' => 1], null);


### PR DESCRIPTION
This test was breaking in kitchen sink because `AbstractQueuedJob` adds specific data when subsites is installed:
https://github.com/symbiote/silverstripe-queuedjobs/blob/d8d4fece6e1e5feec0a3ca6c5c8a0b438a5892c1/src/Services/AbstractQueuedJob.php#L169-L174

## Issue
- https://github.com/silverstripe/.github/issues/125