### PR TITLE
NEW Configuration property for disallowed status codes

### DIFF
--- a/docs/en/basic_configuration.md
+++ b/docs/en/basic_configuration.md
@@ -48,6 +48,18 @@ class MyFormPage extends Page
 }
 ```
 
+## Excluding response codes
+
+Be default, static files are generated for all page responses regardless of the response's status code.
+If you would like to exclude certain status codes from being statically cached, set the `FilesystemPublisher.disallowed_status_codes` configuration property:
+
+```yaml
+SilverStripe\StaticPublishQueue\Publisher\FilesystemPublisher:
+  disallowed_status_codes:
+    - 404
+    - 500
+```
+
 ## Control when child/parent pages are regenerated in cache actions
 
 There are two configurations available, and they can both be set to one of three available values:

--- a/tests/php/Publisher/FilesystemPublisherTest.php
+++ b/tests/php/Publisher/FilesystemPublisherTest.php
@@ -246,6 +246,17 @@ class FilesystemPublisherTest extends SapphireTest
         $this->assertFileDoesNotExist($this->fsp->getDestPath() . 'purge-me.php');
     }
 
+    public function testNoPublishOnDisallowedResponseCode(): void
+    {
+        $this->logOut();
+
+        FilesystemPublisher::config()->set('disallowed_status_codes', [404]);
+
+        $this->fsp->publishURL('not_really_there', true);
+        $this->assertFileDoesNotExist($this->fsp->getDestPath() . 'not_really_there.html');
+        $this->assertFileDoesNotExist($this->fsp->getDestPath() . 'not_really_there.php');
+    }
+
     public function testNoErrorPagesWhenHTMLOnly(): void
     {
         $this->logOut();


### PR DESCRIPTION
Basically a copy-paste from https://github.com/silverstripe/silverstripe-staticpublishqueue/commit/90a22ffd79d61cc6f5c60d9ceef70deebfe422cb which was linked in the issue description.

Requires https://github.com/silverstripe/silverstripe-framework/pull/11082 for tests to go green.

## Issue
- https://github.com/silverstripe/silverstripe-staticpublishqueue/issues/172