### PR TITLE
DEP Bump minimum queuedjobs version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "silverstripe/framework": "^4.6",
         "silverstripe/cms": "^4",
         "silverstripe/config": "^1",
-        "symbiote/silverstripe-queuedjobs": "^4.5",
+        "symbiote/silverstripe-queuedjobs": "^4.7",
         "silverstripe/versioned": "^1.6"
     },
     "require-dev": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/235

Fixes `Fatal error:  Uncaught Symfony\Component\Yaml\Exception\ParseException: The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 8 (near "queueHandler: %$QueueHandler"). in /home/runner/work/silverstripe-staticpublishqueue/silverstripe-staticpublishqueue/vendor/symfony/yaml/Inline.php:305`

https://github.com/silverstripe/silverstripe-staticpublishqueue/actions/runs/8959226326/job/24604388193

Never version of queuedjobs has yaml config that can be parsed