### PR TITLE
DEP Bump minimum version for framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.1",
         "silverstripe/cms": "^5",
         "silverstripe/config": "^2",
         "symbiote/silverstripe-queuedjobs": "^5",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Fixes --prefer-lowest build - https://github.com/silverstripe/silverstripe-staticpublishqueue/actions/runs/9885471530/job/27303570998