### PR TITLE
MNT Update unit test

### DIFF
--- a/tests/php/Publisher/FilesystemPublisherTest.php
+++ b/tests/php/Publisher/FilesystemPublisherTest.php
@@ -285,7 +285,7 @@ class FilesystemPublisherTest extends SapphireTest
         $redirectorPage = RedirectorPage::create();
         $redirectorPage->URLSegment = 'somewhere-else';
         $redirectorPage->RedirectionType = 'External';
-        $redirectorPage->ExternalURL = 'silverstripe.org';
+        $redirectorPage->ExternalURL = 'https://example.org/path';
         $redirectorPage->write();
         $redirectorPage->publishRecursive();
 
@@ -301,7 +301,7 @@ class FilesystemPublisherTest extends SapphireTest
         $this->assertFileExists($this->fsp->getDestPath() . 'somewhere-else.php');
         $phpCacheConfig = require $this->fsp->getDestPath() . 'somewhere-else.php';
         $this->assertSame(301, $phpCacheConfig['responseCode']);
-        $this->assertContains('location: http://silverstripe.org', $phpCacheConfig['headers']);
+        $this->assertContains('location: https://example.org/path', $phpCacheConfig['headers']);
     }
 
     public function testRedirectorPageWhenHTMLOnly(): void


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/320

Location header ended up as `http://example.com/silverstripe.org` - url is missing a scheme and I think the http://example.com came from an alternate_base_url being set elsewhere