### PR TITLE
DEP Conflict queuedjobs 6.0.0-alpha1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
         "silverstripe/standards": "^1",
         "phpstan/extension-installer": "^1.3"
     },
+    "conflict": {
+        "symbiote/silverstripe-queuedjobs": "6.0.0-alpha1"
+    },
     "autoload": {
         "psr-4": {
             "SilverStripe\\StaticPublishQueue\\": "src/",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

Fixes https://github.com/silverstripe/silverstripe-staticpublishqueue/actions/runs/12645068581/job/35285195683#step:10:812

ERROR [Emergency]: Uncaught Error: Undefined constant "Symbiote\QueuedJobs\DataObjects\TEMP_FOLDER"