### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/php/Extension/Engine/SiteTreePublishingEngineTest.php
+++ b/tests/php/Extension/Engine/SiteTreePublishingEngineTest.php
@@ -26,6 +26,10 @@ class SiteTreePublishingEngineTest extends SapphireTest
 {
     protected static $fixture_file = 'SiteTreePublishingEngineTest.yml';
 
+    protected static $extra_dataobjects = [
+        DataObjectNoTrigger::class,
+    ];
+
     protected static $required_extensions = [
         SiteTree::class => [
             PublishableSiteTree::class,
@@ -246,7 +250,8 @@ class SiteTreePublishingEngineTest extends SapphireTest
         /** @var QueuedJobsTestService $service */
         $service = QueuedJobService::singleton();
 
-        $dataObject = DataObjectNoTrigger::create()->write();
+        $dataObject = DataObjectNoTrigger::create();
+        $dataObject->write();
         $dataObject->publishRecursive();
 
         $jobs = $service->getJobs();

--- a/tests/php/StaticPublisherTest/Model/DataObjectNoTrigger.php
+++ b/tests/php/StaticPublisherTest/Model/DataObjectNoTrigger.php
@@ -7,9 +7,10 @@ use SilverStripe\ORM\DataObject;
 
 class DataObjectNoTrigger extends DataObject implements TestOnly
 {
+    private static $table_name = 'StaticPublishQueue_DataObjectNoTrigger';
+
     public function AbsoluteLink()
     {
         return 'http://example.com/subpage/dataobject-1';
     }
 }
-

--- a/tests/php/StaticPublisherTest/Model/ExtensionAddsTrigger.php
+++ b/tests/php/StaticPublisherTest/Model/ExtensionAddsTrigger.php
@@ -24,4 +24,3 @@ class ExtensionAddsTrigger extends Extension implements StaticallyPublishable, S
         return [];
     }
 }
-


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

Fixes https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/12879104438/job/35906085673#step:12:105

`1) SilverStripe\StaticPublishQueue\Test\Extension\Engine\SiteTreePublishingEngineTest::testStaticPublishingTriggerOnExtension
SilverStripe\ORM\Connect\DatabaseException: Couldn't run query: ...`

The unit test SiteTreePublishingEngineTest::testStaticPublishingTriggerOnExtension() doesn't exist on the latest minor branch 6.2, so targeting the 6 branch is correct