### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/php/StaticPublisherTest/Model/ExtensionAddsTrigger.php
+++ b/tests/php/StaticPublisherTest/Model/ExtensionAddsTrigger.php
@@ -16,7 +16,7 @@ class ExtensionAddsTrigger extends Extension implements StaticallyPublishable, S
 
     public function objectsToUpdate($context)
     {
-        return $this->owner;
+        return [$this->owner];
     }
 
     public function objectsToDelete($context)


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

Fixes https://github.com/silverstripe/silverstripe-staticpublishqueue/actions/runs/12900726479/job/35971692192#step:12:107

`TypeError: SilverStripe\StaticPublishQueue\Extension\Engine\SiteTreePublishingEngine::getUrlsFromObjects(): Argument #1 ($objects) must be of type Traversable|array, `
