### PR TITLE
MNT Fix broken unit tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/cms/tests/bootstrap.php"
-         colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage includeUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-        <exclude>
-            <directory suffix=".php">tests/</directory>
-        </exclude>
-    </coverage>
-    <testsuites>
-        <testsuite name="Default">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd">
+  <testsuites>
+    <testsuite name="Default">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">tests/</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/tests/php/Publisher/FilesystemPublisherTest.php
+++ b/tests/php/Publisher/FilesystemPublisherTest.php
@@ -356,21 +356,19 @@ class FilesystemPublisherTest extends SapphireTest
         ];
     }
 
-    public function provideGetPublishedURLs(): array
+    public static function provideGetPublishedURLs(): array
     {
         return [
             [
-                'baseURL' => 'http://example.com',
+                'baseUrl' => 'http://example.com',
             ],
             [
-                'baseURL' => 'https://example.com',
+                'baseUrl' => 'https://example.com',
             ],
         ];
     }
 
-    /**
-     * @dataProvider provideGetPublishedURLs
-     */
+    #[DataProvider('provideGetPublishedURLs')]
     public function testGetPublishedURLs(string $baseUrl): void
     {
         $level1 = new StaticPublisherTestPage();


### PR DESCRIPTION
> [!IMPORTANT]
> Multiple commits, do not squash

Fixes https://github.com/silverstripe/silverstripe-staticpublishqueue/actions/runs/14321832121/job/40140087805

```text
1) SilverStripe\StaticPublishQueue\Test\Publisher\FilesystemPublisherTest::testGetPublishedURLs
The data provider specified for SilverStripe\StaticPublishQueue\Test\Publisher\FilesystemPublisherTest::testGetPublishedURLs is invalid
Data Provider method SilverStripe\StaticPublishQueue\Test\Publisher\FilesystemPublisherTest::provideGetPublishedURLs() is not static

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

2) Metadata found in doc-comment for method SilverStripe\StaticPublishQueue\Test\Publisher\FilesystemPublisherTest::testGetPublishedURLs(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
```

Also fixes the subsequent failure https://github.com/silverstripe/silverstripe-staticpublishqueue/actions/runs/14436130844/job/40477442971?pr=223

```text
1) SilverStripe\StaticPublishQueue\Test\Publisher\FilesystemPublisherTest::testGetPublishedURLs with data set #0 ('http://example.com/')
Error: Unknown named parameter $baseURL
```

## Issue
- https://github.com/silverstripe/.github/issues/389