### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/Publisher/FilesystemPublisherTest.php
+++ b/tests/php/Publisher/FilesystemPublisherTest.php
@@ -66,8 +66,6 @@ class FilesystemPublisherTest extends SapphireTest
     {
         $reflection = new \ReflectionClass(FilesystemPublisher::class);
         $urlToPath = $reflection->getMethod('URLtoPath');
-        $urlToPath->setAccessible(true);
-
         $this->assertSame(
             'index',
             $urlToPath->invokeArgs($this->fsp, ['/'])
@@ -88,8 +86,6 @@ class FilesystemPublisherTest extends SapphireTest
     {
         $reflection = new \ReflectionClass(FilesystemPublisher::class);
         $urlToPath = $reflection->getMethod('URLtoPath');
-        $urlToPath->setAccessible(true);
-
         $url = Director::absoluteBaseUrl();
         $this->assertSame(
             'index',
@@ -115,8 +111,6 @@ class FilesystemPublisherTest extends SapphireTest
 
         $reflection = new \ReflectionClass(FilesystemPublisher::class);
         $urlToPath = $reflection->getMethod('URLtoPath');
-        $urlToPath->setAccessible(true);
-
         $this->fsp->setFileExtension('html');
 
         $url = 'http://domain1.com/';
@@ -150,8 +144,6 @@ class FilesystemPublisherTest extends SapphireTest
 
         $reflection = new \ReflectionClass(FilesystemPublisher::class);
         $urlToPath = $reflection->getMethod('URLtoPath');
-        $urlToPath->setAccessible(true);
-
         $level1 = new StaticPublisherTestPage();
         $level1->URLSegment = 'test-level-1';
         $level1->write();
@@ -338,8 +330,6 @@ class FilesystemPublisherTest extends SapphireTest
     {
         $reflection = new \ReflectionClass(FilesystemPublisher::class);
         $pathToURL = $reflection->getMethod('pathToURL');
-        $pathToURL->setAccessible(true);
-
         $this->assertSame(
             $expected,
             $pathToURL->invoke($this->fsp, $this->fsp->getDestPath() . $path)

--- a/tests/php/Service/UrlBundleServiceTest.php
+++ b/tests/php/Service/UrlBundleServiceTest.php
@@ -69,7 +69,6 @@ class UrlBundleServiceTest extends SapphireTest
         $job = singleton($jobClass);
 
         $method = new ReflectionMethod(Job::class, 'getUrlsPerJob');
-        $method->setAccessible(true);
         $this->assertEquals($urlsPerJob, $method->invoke($job));
     }
 
@@ -82,7 +81,6 @@ class UrlBundleServiceTest extends SapphireTest
         $job = singleton($jobClass);
 
         $method = new ReflectionMethod(Job::class, 'getChunkSize');
-        $method->setAccessible(true);
         $this->assertEquals($chunkSize, $method->invoke($job));
     }
 
@@ -138,7 +136,6 @@ class UrlBundleServiceTest extends SapphireTest
         $urlService = UrlBundleService::create();
         $urlService->addUrls($urls);
         $method = new ReflectionMethod($urlService, 'getUrls');
-        $method->setAccessible(true);
         $resultUrls = $method->invoke($urlService);
 
         $this->assertEqualsCanonicalizing($expectedUrls, $resultUrls);
@@ -156,7 +153,6 @@ class UrlBundleServiceTest extends SapphireTest
         $urlService = UrlBundleService::create();
         $urlService->addUrls($urls);
         $method = new ReflectionMethod($urlService, 'getUrls');
-        $method->setAccessible(true);
         $resultUrls = $method->invoke($urlService);
 
         $this->assertEqualsCanonicalizing($urls, $resultUrls);
@@ -169,8 +165,6 @@ class UrlBundleServiceTest extends SapphireTest
 
         $urlService = UrlBundleService::create();
         $method = new ReflectionMethod($urlService, 'stripStageParam');
-        $method->setAccessible(true);
-
         $this->assertEquals($expectedUrl, $method->invoke($urlService, $url));
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
